### PR TITLE
use more compact integer headers

### DIFF
--- a/channel2/message.go
+++ b/channel2/message.go
@@ -98,46 +98,76 @@ func (header *MessageHeader) IsReplyingTo(sequence int32) bool {
 
 func (header *MessageHeader) PutUint64Header(key int32, value uint64) {
 	encoded := make([]byte, 8)
-	binary.LittleEndian.PutUint64(encoded, value)
+	encoded = encoded[:0]
+	for value > 0 {
+		encoded = append(encoded, byte(value))
+		value = value >> 8
+	}
 	header.Headers[key] = encoded
 }
 
 func (header *MessageHeader) GetUint64Header(key int32) (uint64, bool) {
 	encoded, ok := header.Headers[key]
-	if !ok || len(encoded) != 8 {
+	if !ok {
 		return 0, ok
 	}
-	result := binary.LittleEndian.Uint64(encoded)
+	if len(encoded) > 8 {
+		encoded = encoded[0:8]
+	}
+	var result uint64
+	for i, b := range encoded {
+		result += uint64(b) << (i * 8)
+	}
 	return result, true
 }
 
 func (header *MessageHeader) PutUint32Header(key int32, value uint32) {
 	encoded := make([]byte, 4)
-	binary.LittleEndian.PutUint32(encoded, value)
+	encoded = encoded[:0]
+	for value > 0 {
+		encoded = append(encoded, byte(value))
+		value = value >> 8
+	}
 	header.Headers[key] = encoded
 }
 
 func (header *MessageHeader) GetUint32Header(key int32) (uint32, bool) {
 	encoded, ok := header.Headers[key]
-	if !ok || len(encoded) != 4 {
-		return 0, false
+	if !ok {
+		return 0, ok
 	}
-	result := binary.LittleEndian.Uint32(encoded)
+	if len(encoded) > 4 {
+		encoded = encoded[0:4]
+	}
+	var result uint32
+	for i, b := range encoded {
+		result += uint32(b) << (i * 8)
+	}
 	return result, true
 }
 
 func (header *MessageHeader) PutUint16Header(key int32, value uint16) {
 	encoded := make([]byte, 2)
-	binary.LittleEndian.PutUint16(encoded, value)
+	encoded = encoded[:0]
+	for value > 0 {
+		encoded = append(encoded, byte(value))
+		value = value >> 8
+	}
 	header.Headers[key] = encoded
 }
 
 func (header *MessageHeader) GetUint16Header(key int32) (uint16, bool) {
 	encoded, ok := header.Headers[key]
-	if !ok || len(encoded) != 2 {
-		return 0, false
+	if !ok {
+		return 0, ok
 	}
-	result := binary.LittleEndian.Uint16(encoded)
+	if len(encoded) > 2 {
+		encoded = encoded[0:2]
+	}
+	var result uint16
+	for i, b := range encoded {
+		result += uint16(b) << (i * 8)
+	}
 	return result, true
 }
 

--- a/channel2/message_test.go
+++ b/channel2/message_test.go
@@ -61,3 +61,126 @@ func Test_getRetryVersionFor(t *testing.T) {
 		})
 	}
 }
+
+func TestMessageHeader_PutUint64Header(t *testing.T) {
+	testHeader := int32(1111)
+	type args struct {
+		key   int32
+		value uint64
+	}
+	tests := []struct {
+		name   string
+		len    int
+		args   args
+	}{
+		{name: "0 byte", len: 0, args: args{ key:testHeader, value: uint64(0)}},
+		{name: "1 byte", len: 1, args: args{ key:testHeader, value: uint64(0x1)}},
+		{name: "2 byte", len: 2, args: args{ key:testHeader, value: uint64(0x0201)}},
+		{name: "3 byte", len: 3, args: args{ key:testHeader, value: uint64(0x030201)}},
+		{name: "4 byte", len: 4, args: args{ key:testHeader, value: uint64(0x04030201)}},
+		{name: "5 byte", len: 5, args: args{ key:testHeader, value: uint64(0x0504030201)}},
+		{name: "6 byte", len: 6, args: args{ key:testHeader, value: uint64(0x060504030201)}},
+		{name: "7 byte", len: 7, args: args{ key:testHeader, value: uint64(0x07060504000001)}},
+		{name: "8 byte", len: 8, args: args{ key:testHeader, value: uint64(0x0807060504000000)}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := &MessageHeader{
+				Headers:     make(map[int32][]byte),
+			}
+
+			header.PutUint64Header(tt.args.key, tt.args.value)
+			binary, err := marshalHeaders(header.Headers)
+			if err != nil {
+				t.Error(tt.name, err)
+			}
+
+			header.Headers, err = unmarshalHeaders(binary)
+			if err != nil {
+				t.Error(tt.name, err)
+			}
+
+			if tt.len != len(header.Headers[testHeader]) {
+				t.Errorf("%s: unexpected header len", tt.name)
+			}
+
+			v, found := header.GetUint64Header(tt.args.key)
+			if !found {
+				t.Errorf("%s: put failed", tt.name)
+			}
+			if v != tt.args.value {
+				t.Errorf("%s: %d(%v) != %v", tt.name, v, header.Headers[tt.args.key], tt.args.value)
+			}
+		})
+	}
+}
+
+func TestMessageHeader_PutUint32Header(t *testing.T) {
+	testHeader := int32(1111)
+	type args struct {
+		key   int32
+		value uint32
+	}
+	tests := []struct {
+		name   string
+		len    int
+		args   args
+	}{
+		{name: "0 byte", len:0, args: args{ key:testHeader, value: uint32(0)}},
+		{name: "1 byte", len:1, args: args{ key:testHeader, value: uint32(0x1)}},
+		{name: "2 byte", len:2, args: args{ key:testHeader, value: uint32(0x0201)}},
+		{name: "3 byte", len:3, args: args{ key:testHeader, value: uint32(0x030201)}},
+		{name: "4 byte", len:4, args: args{ key:testHeader, value: uint32(0x04030201)}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := &MessageHeader{
+				Headers:     make(map[int32][]byte),
+			}
+
+			header.PutUint32Header(tt.args.key, tt.args.value)
+			if tt.len != len(header.Headers[testHeader]) {
+				t.Errorf("%s: unexpected header len", tt.name)
+			}
+			v, found := header.GetUint32Header(tt.args.key)
+			if !found {
+				t.Errorf("%s: put failed", tt.name)
+			}
+			if v != tt.args.value {
+				t.Errorf("%s: %d(%v) != %v", tt.name, v, header.Headers[tt.args.key], tt.args.value)
+			}
+		})
+	}
+}
+
+func TestMessageHeader_PutUint16Header(t *testing.T) {
+	testHeader := int32(1111)
+	type args struct {
+		key   int32
+		value uint16
+	}
+	tests := []struct {
+		name   string
+		args   args
+	}{
+		{name: "0 byte", args: args{ key:testHeader, value: uint16(0)}},
+		{name: "1 byte", args: args{ key:testHeader, value: uint16(0x1)}},
+		{name: "2 byte", args: args{ key:testHeader, value: uint16(0xFF00)}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := &MessageHeader{
+				Headers:     make(map[int32][]byte),
+			}
+
+			header.PutUint16Header(tt.args.key, tt.args.value)
+			v, found := header.GetUint16Header(tt.args.key)
+			if !found {
+				t.Errorf("%s: put failed", tt.name)
+			}
+			if v != tt.args.value {
+				t.Errorf("%s: %d(%v) != %v", tt.name, v, header.Headers[tt.args.key], tt.args.value)
+			}
+		})
+	}
+}

--- a/channel2/message_test.go
+++ b/channel2/message_test.go
@@ -17,6 +17,7 @@
 package channel2
 
 import (
+	"encoding/binary"
 	"errors"
 	"testing"
 )
@@ -64,6 +65,8 @@ func Test_getRetryVersionFor(t *testing.T) {
 
 func TestMessageHeader_PutUint64Header(t *testing.T) {
 	testHeader := int32(1111)
+	testLEHeader := int32(2222)
+
 	type args struct {
 		key   int32
 		value uint64
@@ -90,6 +93,10 @@ func TestMessageHeader_PutUint64Header(t *testing.T) {
 			}
 
 			header.PutUint64Header(tt.args.key, tt.args.value)
+			leVal := make([]byte,8)
+			binary.LittleEndian.PutUint64(leVal, tt.args.value)
+			header.Headers[testLEHeader] = leVal
+
 			binary, err := marshalHeaders(header.Headers)
 			if err != nil {
 				t.Error(tt.name, err)
@@ -110,6 +117,14 @@ func TestMessageHeader_PutUint64Header(t *testing.T) {
 			}
 			if v != tt.args.value {
 				t.Errorf("%s: %d(%v) != %v", tt.name, v, header.Headers[tt.args.key], tt.args.value)
+			}
+
+			leV, found := header.GetUint64Header(testLEHeader)
+			if !found {
+				t.Errorf("%s: put failed", tt.name)
+			}
+			if leV != tt.args.value {
+				t.Errorf("%s: %d(%v) != %v", tt.name, leV, header.Headers[tt.args.key], tt.args.value)
 			}
 		})
 	}


### PR DESCRIPTION
use more compact wire representation for uint16/32/64 headers

`uint32(1)` would translate to 1 byte instead of 4
