### PR TITLE
'short read' -> io.EOF

### DIFF
--- a/channel2/message.go
+++ b/channel2/message.go
@@ -313,7 +313,9 @@ func ReadWSMessage(peer io.Reader) (*Message, error) {
 func readV2(peer io.Reader) (*Message, error) {
 	messageSection := make([]byte, dataSectionV2)
 	read, err := io.ReadFull(peer, messageSection)
-
+	if err == io.EOF {
+		return nil, err
+	}
 	if read < 4 {
 		return nil, errors.New("short read")
 	}


### PR DESCRIPTION
Stop swallowing `EOF` messages when they occur (they end up looking like a `short read`, otherwise).