### PR TITLE
avoid panics on deletes w/ empty cowslice

### DIFF
--- a/util/cowslice/registry.go
+++ b/util/cowslice/registry.go
@@ -38,7 +38,13 @@ func Delete(registry *CowSlice, listener interface{}) {
 	t := reflect.TypeOf(currentSlice)
 	val := reflect.ValueOf(currentSlice)
 
-	newSlice := reflect.MakeSlice(t, 0, val.Len()-1)
+	cap := val.Len() - 1
+
+	if cap < 0 {
+		cap = 0
+	}
+
+	newSlice := reflect.MakeSlice(t, 0, cap)
 	for i := 0; i < val.Len(); i++ {
 		next := val.Index(i)
 		if next.Interface() != listener {

--- a/util/cowslice/registry_test.go
+++ b/util/cowslice/registry_test.go
@@ -62,17 +62,33 @@ func TestCowSlice_Append(t *testing.T) {
 func TestCloseSlice_Delete(t *testing.T) {
 
 	t.Run("adding and removing a single element succeeds", func(t *testing.T) {
+		req := require.New(t)
 		cw := NewCowSlice(make([]testHandler, 0))
 
 		h := &testHandlerImpl{}
 		Append(cw, h)
 		Delete(cw, h)
+
+		cur := cw.Value()
+		req.NotNil(cur)
+
+		tc, ok := cur.([]testHandler)
+		req.True(ok)
+		req.Equal(0, len(tc))
 	})
 
-	t.Run("delete on empty cow slice does not fail", func(t *testing.T) {
+	t.Run("delete on empty cow slice does not panic", func(t *testing.T) {
+		req := require.New(t)
 		cw := NewCowSlice(make([]testHandler, 0))
 
 		h := &testHandlerImpl{}
 		Delete(cw, h)
+
+		cur := cw.Value()
+		req.NotNil(cur)
+
+		tc, ok := cur.([]testHandler)
+		req.True(ok)
+		req.Equal(0, len(tc))
 	})
 }

--- a/util/cowslice/registry_test.go
+++ b/util/cowslice/registry_test.go
@@ -58,3 +58,21 @@ func TestCowSlice_Append(t *testing.T) {
 	tc = cur.([]testHandler)
 	req.Equal(0, len(tc))
 }
+
+func TestCloseSlice_Delete(t *testing.T) {
+
+	t.Run("adding and removing a single element succeeds", func(t *testing.T) {
+		cw := NewCowSlice(make([]testHandler, 0))
+
+		h := &testHandlerImpl{}
+		Append(cw, h)
+		Delete(cw, h)
+	})
+
+	t.Run("delete on empty cow slice does not fail", func(t *testing.T) {
+		cw := NewCowSlice(make([]testHandler, 0))
+
+		h := &testHandlerImpl{}
+		Delete(cw, h)
+	})
+}


### PR DESCRIPTION
This was causing a panic when router.Shutdown() was called because it doesn't handle Delete on an empty value (see https://github.com/openziti/ziti/pull/345 )

I am still looking into why something was trying to delete on an empty cowslice.

