### PR TITLE
use HTTP Bad Request instead of SIP Temporarily Unavailable

### DIFF
--- a/util/errorz/messages.go
+++ b/util/errorz/messages.go
@@ -36,7 +36,7 @@ const (
 const (
 	InvalidFilterCode       string = "INVALID_FILTER"
 	InvalidFilterMessage    string = "The filter query supplied is invalid"
-	httpStatusInvalidFilter        = 480
+	httpStatusInvalidFilter        = http.StatusBadRequest
 	InvalidFilterStatus     int    = httpStatusInvalidFilter
 
 	InvalidPaginationCode    string = "INVALID_PAGINATION"


### PR DESCRIPTION
`480` isn't defined in the API Spec and causes those clients to error out with unexpected status codes. Additionally, `480` isn't a standard HTTP status, but a SIP over HTTP Status for "temporarily unavailable" which isn't semantically correct. If a client submitted an invalid filter, their request is invalid. `400 Bad Request` properly conveys that the client did something wrong, the server/resources/etc are fine, and the request should be fixed and not sent again as is.