### PR TITLE
Add channel id to ProbeLatency log message

### DIFF
--- a/metrics/latency.go
+++ b/metrics/latency.go
@@ -19,7 +19,6 @@ package metrics
 import (
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/foundation/channel2"
-	"github.com/sirupsen/logrus"
 	"time"
 )
 


### PR DESCRIPTION
Added the channel ID to the ProbeLatency message to give the timeouts more context.