### PR TITLE
updates identity config support

### DIFF
--- a/identity/identity/config.go
+++ b/identity/identity/config.go
@@ -1,0 +1,219 @@
+package identity
+
+/*
+	Copyright NetFoundry, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	ConfigFieldCert = "cert"
+	ConfigFieldKey = "key"
+	ConfigFieldServerCert = "server_cert"
+	ConfigFieldServerKey = "server_key"
+	ConfigFieldCa = "ca"
+)
+
+// Config represents the basic data structure for and identity configuration. A Config provides details on where the
+// x509 certificates and private keys are located/stored for the identity. These values are interpreted by the
+// LoadIdentity function to produce an Identity that can be used to create crypto configurations (i.e. tls.Config).
+// Storage locations include files, in-memory PEM, and hardware tokens.
+//
+// Key, Cert, ServerCert, ServerKey, and CA are URLs with the following schemes: `file`, `pem`. Additionally,
+// Key supports `engine`. If the value is not in URL format it is assumed to be `file`.
+//
+// Example: `file://path/to/my/cert.pem` or `path/to/my/cert.pem'
+// Example: `pem://-----BEGIN CERTIFICATE-----\nMIIB/TCCAYCgAwIBAgIBATAMBggqhk...`
+type Config struct {
+	Key        string `json:"key" yaml:"key" mapstructure:"key"`
+	Cert       string `json:"cert" yaml:"cert" mapstructure:"cert"`
+	ServerCert string `json:"server_cert,omitempty" yaml:"server_cert,omitempty" mapstructure:"server_cert,omitempty"`
+	ServerKey  string `json:"server_key,omitempty" yaml:"server_key,omitempty" mapstructure:"server_key,omitempty"`
+	CA         string `json:"ca,omitempty" yaml:"ca,omitempty" mapstructure:"ca"`
+}
+
+// Validate validates the current IdentityConfiguration to have non-empty values all fields except
+// ServerKey which assumes that Key is a suitable default.
+func (config *Config) Validate() error {
+	return config.ValidateWithPathContext("")
+}
+
+// ValidateWithPathContext performs the same checks as Validate but also allows a path context to be
+// provided for error messages when parsing deep or complex configuration.
+//
+// Example:
+//  `ValidateWithPathContext("my.path")`  errors would be formatted as "required configuration value [my.path.cert]..."`
+func (config *Config) ValidateWithPathContext(pathContext string) error {
+	pathContext = strings.TrimSpace(pathContext)
+
+	if pathContext != "" {
+		if !strings.HasSuffix(pathContext, ".") {
+			pathContext = pathContext + "."
+		}
+	}
+
+	if config.Cert == "" {
+		return fmt.Errorf("required configuration value [%s%s] is missing or is blank", pathContext, ConfigFieldCert)
+	}
+
+	if config.ServerCert == "" {
+		return fmt.Errorf("required configuration value [%s%s] is missing or is blank", pathContext, ConfigFieldServerCert)
+	}
+
+	if config.Key == "" {
+		return fmt.Errorf("required configuration value [%s%s] is missing or is blank", pathContext, ConfigFieldKey)
+	}
+
+	if config.CA == "" {
+		return fmt.Errorf("required configuration value [%s%s] is missing or is blank", pathContext, ConfigFieldCa)
+	}
+
+	return nil
+}
+
+// ValidateForClient validates the current IdentityConfiguration has enough values to initiate a client connection.
+// For example: a tls.Config for a client in mTLS
+func (config *Config) ValidateForClient() error {
+	return config.ValidateForClientWithPathContext("")
+}
+
+// ValidateForClientWithPathContext performs the same checks as ValidateForClient but also allows a path context to be
+// provided for error messages when parsing deep or complex configuration.
+//
+// Example:
+//  `ValidateForClientWithPathContext("my.path")`  errors would be formatted as "required configuration value [my.path.cert]..."`
+func (config *Config) ValidateForClientWithPathContext(pathContext string) error {
+	pathContext = strings.TrimSpace(pathContext)
+
+	if pathContext != "" {
+		if !strings.HasSuffix(pathContext, ".") {
+			pathContext = pathContext + "."
+		}
+	}
+
+	if config.Cert == "" {
+		return fmt.Errorf("required configuration value [%s%s] is missing or is blank", pathContext, ConfigFieldCert)
+	}
+
+	if config.Key == "" {
+		return fmt.Errorf("required configuration value [%s%s] is missing or is blank", pathContext, ConfigFieldKey)
+	}
+
+	return nil
+}
+
+// ValidateForServer validates the current IdentityConfiguration has enough values to a client connection.
+// For example: a tls.Config for a server in mTLS
+func (config *Config) ValidateForServer() error {
+	return config.ValidateForServerWithPathContext("")
+}
+
+// ValidateForServerWithPathContext performs the same checks as ValidateForServer but also allows a path context to be
+// provided for error messages when parsing deep or complex configuration.
+//
+// Example:
+//  `ValidateWithPathContext("my.path")`  errors would be formatted as "required configuration value [my.path.cert]..."`
+func (config *Config) ValidateForServerWithPathContext(pathContext string) error {
+	pathContext = strings.TrimSpace(pathContext)
+
+	if pathContext != "" {
+		if !strings.HasSuffix(pathContext, ".") {
+			pathContext = pathContext + "."
+		}
+	}
+
+	if config.ServerCert == "" {
+		return fmt.Errorf("required configuration value [%s%s] is missing or is blank", pathContext, ConfigFieldServerCert)
+	}
+
+	if config.Key == "" && config.ServerKey == "" {
+		return fmt.Errorf("required configuration values [%s%s], [%s%s] are both missing or are blank", pathContext, ConfigFieldKey, pathContext, ConfigFieldServerKey)
+	}
+
+	if config.CA == "" {
+		return fmt.Errorf("required configuration value [%s%s] is missing or is blank", pathContext, ConfigFieldCa)
+	}
+
+	return nil
+}
+
+// NewConfigFromMap will parse a standard identity configuration section that has been loaded from JSON/YAML/etc.
+// parse functions that return interface{} maps. It expects the following fields to be defined as strings if present.
+// If any fields are missing they are left as empty string in the resulting Config.
+func NewConfigFromMap(identityMap map[interface{}]interface{}) (*Config, error) {
+	return NewConfigFromMapWithPathContext(identityMap, "")
+}
+
+// NewConfigFromMapWithPathContext performs the same checks as NewConfigFromMap but also allows a path context to be
+// provided for error messages when parsing deep or complex configuration.
+//
+// Example:
+//  `NewConfigFromMapWithPathContext(myMap, "my.path")` errors would be formatted as "value [my.path.cert] must be a string"`
+func NewConfigFromMapWithPathContext(identityMap map[interface{}]interface{}, pathContext string) (*Config, error) {
+	pathContext = strings.TrimSpace(pathContext)
+
+	if pathContext != "" {
+		if !strings.HasSuffix(pathContext, ".") {
+			pathContext = pathContext + "."
+		}
+	}
+
+	idConfig := &Config{}
+
+	if certInterface, ok := identityMap[ConfigFieldCert]; ok {
+		if cert, ok := certInterface.(string); ok {
+			idConfig.Cert = cert
+		} else {
+			return nil, fmt.Errorf("value [%s%s] must be a string", pathContext, ConfigFieldCert)
+		}
+	}
+
+	if serverCertInterface, ok := identityMap[ConfigFieldServerCert]; ok {
+		if serverCert, ok := serverCertInterface.(string); ok {
+			idConfig.ServerCert = serverCert
+		} else {
+			return nil, fmt.Errorf("value [%s%s] must be a string", pathContext, ConfigFieldServerCert)
+		}
+	}
+
+	if keyInterface, ok := identityMap[ConfigFieldKey]; ok {
+		if key, ok := keyInterface.(string); ok {
+			idConfig.Key = key
+		} else {
+			return nil, fmt.Errorf("value [%s%s] must be a string", pathContext, ConfigFieldKey)
+		}
+	}
+
+	if keyInterface, ok := identityMap[ConfigFieldServerKey]; ok {
+		if serverKey, ok := keyInterface.(string); ok {
+			idConfig.ServerKey = serverKey
+		} else {
+			return nil, fmt.Errorf("value [%s%s] must be a string", pathContext, ConfigFieldServerKey)
+		}
+	}
+
+	if caInterface, ok := identityMap[ConfigFieldCa]; ok {
+		if ca, ok := caInterface.(string); ok {
+			idConfig.CA = ca
+		} else {
+			return nil, fmt.Errorf("value [%s%s] must be a string", pathContext, ConfigFieldCa)
+		}
+	}
+
+	return idConfig, nil
+}

--- a/identity/identity/config_test.go
+++ b/identity/identity/config_test.go
@@ -1,0 +1,825 @@
+package identity
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+	"testing"
+)
+
+/*
+	Copyright NetFoundry, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+const (
+	TestValueCert       = "./ziti/etc/ca/intermediate/certs/ctrl-client.cert.pem"
+	TestValueKey        = "./ziti/etc/ca/intermediate/private/ctrl.key.pem"
+	TestValueServerCert = "./ziti/etc/ca/intermediate/certs/ctrl-server.cert.pem"
+	TestValueServerKey  = "./ziti/etc/ca/intermediate/certs/ctrl-server.key.pem"
+	TestValueCa         = "./ziti/etc/ca/intermediate/certs/ca-chain.cert.pem"
+
+	TestValuePathContext = "my.path"
+
+	TestValueMissingOrBlankFieldErrorTemplate = "required configuration value [%s] is missing or is blank"
+	TestValueMissingOrBlankFieldsTemplate     = "required configuration values [%s], [%s] are both missing or are blank"
+	TestValueMapStringErrorTemplate           = "value [%s] must be a string"
+
+	TestValueJsonTemplate                     = `
+		{
+		  "cert": "%s",
+		  "key": "%s",
+		  "server_cert": "%s",
+		  "server_key": "%s",
+		  "ca": "%s"
+		}`
+
+	TestValueYamlTemplate = `
+cert: "%s"
+key: "%s"
+server_cert: "%s"
+server_key: "%s"
+ca: "%s"
+`
+)
+
+func Test_Config(t *testing.T) {
+	t.Run("can parse from JSON", func(t *testing.T) {
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, TestValueServerKey, TestValueCa))
+
+		config := Config{}
+		err := json.Unmarshal(identityConfigJson, &config)
+
+		req := require.New(t)
+		req.NoError(err)
+		req.Equal(config.Cert, TestValueCert)
+		req.Equal(config.Key, TestValueKey)
+		req.Equal(config.ServerCert, TestValueServerCert)
+		req.Equal(config.ServerKey, TestValueServerKey)
+		req.Equal(config.CA, TestValueCa)
+	})
+
+	t.Run("can parse from YAML", func(t *testing.T) {
+		identityConfigYaml := []byte(fmt.Sprintf(TestValueYamlTemplate, TestValueCert, TestValueKey, TestValueServerCert, TestValueServerKey, TestValueCa))
+
+		config := Config{}
+		err := yaml.Unmarshal(identityConfigYaml, &config)
+
+		req := require.New(t)
+		req.NoError(err)
+		req.Equal(config.Cert, TestValueCert)
+		req.Equal(config.Key, TestValueKey)
+		req.Equal(config.ServerCert, TestValueServerCert)
+		req.Equal(config.ServerKey, TestValueServerKey)
+		req.Equal(config.CA, TestValueCa)
+	})
+}
+
+func Test_Config_Validate(t *testing.T) {
+	t.Run("all fields present returns no errors", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+		err := json.Unmarshal(identityConfigJson, &config)
+
+		req.NoError(err)
+		req.NoError(config.Validate())
+	})
+
+	t.Run("all fields present returns no errors", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+		err := json.Unmarshal(identityConfigJson, &config)
+
+		req.NoError(err)
+		req.NoError(config.Validate())
+	})
+
+	t.Run("empty string cert returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, "", TestValueKey, TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.Validate()
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldErrorTemplate, "cert"))
+	})
+
+	t.Run("empty string key returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, "", TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.Validate()
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldErrorTemplate, "key"))
+	})
+
+	t.Run("empty string server_cert returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, "", TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.Validate()
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldErrorTemplate, "server_cert"))
+	})
+
+	t.Run("empty string ca returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, TestValueServerKey, ""))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.Validate()
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldErrorTemplate, "ca"))
+	})
+
+	t.Run("empty string server_key returns no error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, "", TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.Validate()
+		req.NoError(err)
+	})
+}
+
+func Test_Config_ValidateWithPathContext(t *testing.T) {
+	t.Run("all fields present returns no errors", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+		err := json.Unmarshal(identityConfigJson, &config)
+
+		req.NoError(err)
+		req.NoError(config.ValidateWithPathContext(TestValuePathContext))
+	})
+
+	t.Run("empty string cert returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, "", TestValueKey, TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateWithPathContext(TestValuePathContext)
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldErrorTemplate, TestValuePathContext+".cert"))
+	})
+
+	t.Run("empty string key returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, "", TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateWithPathContext(TestValuePathContext)
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldErrorTemplate, TestValuePathContext+".key"))
+	})
+
+	t.Run("empty string server_cert returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, "", TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateWithPathContext(TestValuePathContext)
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldErrorTemplate, TestValuePathContext+".server_cert"))
+	})
+
+	t.Run("empty string ca returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, TestValueServerKey, ""))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateWithPathContext(TestValuePathContext)
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldErrorTemplate, TestValuePathContext+".ca"))
+	})
+
+	t.Run("empty string server_key returns no error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, "", TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateWithPathContext(TestValuePathContext)
+		req.NoError(err)
+	})
+}
+
+func Test_Config_ValidateForClient(t *testing.T) {
+	t.Run("all fields present returns no errors", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+		err := json.Unmarshal(identityConfigJson, &config)
+
+		req.NoError(err)
+		req.NoError(config.ValidateForClient())
+	})
+
+	t.Run("minimum fields present returns no errors", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, "", "", ""))
+		config := Config{}
+		err := json.Unmarshal(identityConfigJson, &config)
+
+		req.NoError(err)
+		req.NoError(config.ValidateForClient())
+	})
+
+	t.Run("empty string cert returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, "", TestValueKey, TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForClient()
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldErrorTemplate, "cert"))
+	})
+
+	t.Run("empty string key returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, "", TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForClient()
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldErrorTemplate, "key"))
+	})
+
+	t.Run("empty string server_cert returns no error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, "", TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForClient()
+		req.NoError(err)
+	})
+
+	t.Run("empty string ca returns no error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, TestValueServerKey, ""))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForClient()
+		req.NoError(err)
+	})
+
+	t.Run("empty string server_key returns no error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, "", TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForClient()
+		req.NoError(err)
+	})
+}
+
+func Test_Config_ValidateForClientWithPathContext(t *testing.T) {
+
+	t.Run("all fields present returns no errors", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+		err := json.Unmarshal(identityConfigJson, &config)
+
+		req.NoError(err)
+		req.NoError(config.ValidateForClientWithPathContext(TestValuePathContext))
+	})
+
+	t.Run("minimum fields present returns no errors", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, "", "", ""))
+		config := Config{}
+		err := json.Unmarshal(identityConfigJson, &config)
+
+		req.NoError(err)
+		req.NoError(config.ValidateForClientWithPathContext(TestValuePathContext))
+	})
+
+	t.Run("empty string cert returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, "", TestValueKey, TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForClientWithPathContext(TestValuePathContext)
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldErrorTemplate, TestValuePathContext+".cert"))
+	})
+
+	t.Run("empty string key returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, "", TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForClientWithPathContext(TestValuePathContext)
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldErrorTemplate, TestValuePathContext+".key"))
+	})
+
+	t.Run("empty string server_cert returns no error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, "", TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForClientWithPathContext(TestValuePathContext)
+		req.NoError(err)
+	})
+
+	t.Run("empty string ca returns no error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, TestValueServerKey, ""))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForClientWithPathContext(TestValuePathContext)
+		req.NoError(err)
+	})
+
+	t.Run("empty string server_key returns no error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, "", TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForClientWithPathContext(TestValuePathContext)
+		req.NoError(err)
+	})
+}
+
+func Test_Config_ValidateForServer(t *testing.T) {
+	t.Run("all fields present returns no errors", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+		err := json.Unmarshal(identityConfigJson, &config)
+
+		req.NoError(err)
+		req.NoError(config.ValidateForServer())
+	})
+
+	t.Run("minimum fields present returns no errors", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, "", "", TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+		err := json.Unmarshal(identityConfigJson, &config)
+
+		req.NoError(err)
+		req.NoError(config.ValidateForServer())
+	})
+
+	t.Run("minimum fields present no server_key returns no errors", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, "", TestValueKey, TestValueServerCert, "", TestValueCa))
+		config := Config{}
+		err := json.Unmarshal(identityConfigJson, &config)
+
+		req.NoError(err)
+		req.NoError(config.ValidateForServer())
+	})
+
+	t.Run("empty string cert returns no error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, "", TestValueKey, TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForServer()
+		req.NoError(err)
+	})
+
+	t.Run("empty string key returns no error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, "", TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForServer()
+		req.NoError(err)
+	})
+
+	t.Run("empty string server_cert returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, "", TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForServer()
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldErrorTemplate, "server_cert"))
+	})
+
+	t.Run("empty string ca returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, TestValueServerKey, ""))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForServer()
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldErrorTemplate, "ca"))
+	})
+
+	t.Run("empty string server_key and no default key returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, "", TestValueServerCert, "", TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForServer()
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldsTemplate, "key", "server_key"))
+	})
+}
+
+func Test_Config_ValidateForServerWithPathContext(t *testing.T) {
+	t.Run("all fields present returns no errors", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+		err := json.Unmarshal(identityConfigJson, &config)
+
+		req.NoError(err)
+		req.NoError(config.ValidateForServerWithPathContext(TestValuePathContext))
+	})
+
+	t.Run("minimum fields present returns no errors", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, "", "", TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+		err := json.Unmarshal(identityConfigJson, &config)
+
+		req.NoError(err)
+		req.NoError(config.ValidateForServerWithPathContext(TestValuePathContext))
+	})
+
+	t.Run("minimum fields present no server_key returns no errors", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, "", TestValueKey, TestValueServerCert, "", TestValueCa))
+		config := Config{}
+		err := json.Unmarshal(identityConfigJson, &config)
+
+		req.NoError(err)
+		req.NoError(config.ValidateForServerWithPathContext(TestValuePathContext))
+	})
+
+	t.Run("empty string cert returns no error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, "", TestValueKey, TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForServerWithPathContext(TestValuePathContext)
+		req.NoError(err)
+	})
+
+	t.Run("empty string key returns no error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, "", TestValueServerCert, TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForServerWithPathContext(TestValuePathContext)
+		req.NoError(err)
+	})
+
+	t.Run("empty string server_cert returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, "", TestValueServerKey, TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForServerWithPathContext(TestValuePathContext)
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldErrorTemplate, TestValuePathContext+".server_cert"))
+	})
+
+	t.Run("empty string ca returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, TestValueKey, TestValueServerCert, TestValueServerKey, ""))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForServerWithPathContext(TestValuePathContext)
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldErrorTemplate, TestValuePathContext+".ca"))
+	})
+
+	t.Run("empty string server_key and no default key returns error", func(t *testing.T) {
+		req := require.New(t)
+		identityConfigJson := []byte(fmt.Sprintf(TestValueJsonTemplate, TestValueCert, "", TestValueServerCert, "", TestValueCa))
+		config := Config{}
+
+		err := json.Unmarshal(identityConfigJson, &config)
+		req.NoError(err)
+
+		err = config.ValidateForServerWithPathContext(TestValuePathContext)
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMissingOrBlankFieldsTemplate, TestValuePathContext+".key", TestValuePathContext+".server_key"))
+	})
+}
+
+func Test_NewConfigFromMap(t *testing.T) {
+	t.Run("can parse all values from a map", func(t *testing.T) {
+		req := require.New(t)
+
+		configMap := map[interface{}]interface{}{
+			"cert":        TestValueCert,
+			"key":         TestValueKey,
+			"server_cert": TestValueServerCert,
+			"server_key":  TestValueServerKey,
+			"ca":          TestValueCa,
+		}
+
+		config, err := NewConfigFromMap(configMap)
+
+		req.NoError(err)
+		req.Equal(config.Cert, TestValueCert)
+		req.Equal(config.Key, TestValueKey)
+		req.Equal(config.ServerCert, TestValueServerCert)
+		req.Equal(config.ServerKey, TestValueServerKey)
+		req.Equal(config.CA, TestValueCa)
+	})
+
+	t.Run("errors on non-string cert", func(t *testing.T) {
+		req := require.New(t)
+
+		configMap := map[interface{}]interface{}{
+			"cert":        1,
+			"key":         TestValueKey,
+			"server_cert": TestValueServerCert,
+			"server_key":  TestValueServerKey,
+			"ca":          TestValueCa,
+		}
+
+		_, err := NewConfigFromMap(configMap)
+
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMapStringErrorTemplate, "cert"))
+	})
+
+	t.Run("errors on non-string key", func(t *testing.T) {
+		req := require.New(t)
+
+		configMap := map[interface{}]interface{}{
+			"cert":        TestValueCert,
+			"key":         1,
+			"server_cert": TestValueServerCert,
+			"server_key":  TestValueServerKey,
+			"ca":          TestValueCa,
+		}
+
+		_, err := NewConfigFromMap(configMap)
+
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMapStringErrorTemplate, "key"))
+	})
+
+	t.Run("errors on non-string server_cert", func(t *testing.T) {
+		req := require.New(t)
+
+		configMap := map[interface{}]interface{}{
+			"cert":        TestValueCert,
+			"key":         TestValueKey,
+			"server_cert": 1,
+			"server_key":  TestValueServerKey,
+			"ca":          TestValueCa,
+		}
+
+		_, err := NewConfigFromMap(configMap)
+
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMapStringErrorTemplate, "server_cert"))
+	})
+
+	t.Run("errors on non-string server_key", func(t *testing.T) {
+		req := require.New(t)
+
+		configMap := map[interface{}]interface{}{
+			"cert":        TestValueCert,
+			"key":         TestValueKey,
+			"server_cert": TestValueServerCert,
+			"server_key":  1,
+			"ca":          TestValueCa,
+		}
+
+		_, err := NewConfigFromMap(configMap)
+
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMapStringErrorTemplate, "server_key"))
+	})
+
+	t.Run("errors on non-string ca", func(t *testing.T) {
+		req := require.New(t)
+
+		configMap := map[interface{}]interface{}{
+			"cert":        TestValueCert,
+			"key":         TestValueKey,
+			"server_cert": TestValueServerCert,
+			"server_key":  TestValueServerKey,
+			"ca":          1,
+		}
+
+		_, err := NewConfigFromMap(configMap)
+
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMapStringErrorTemplate, "ca"))
+	})
+}
+
+func Test_NewConfigFromMapWithPathContext(t *testing.T) {
+	t.Run("can parse all values from a map", func(t *testing.T) {
+		req := require.New(t)
+
+		configMap := map[interface{}]interface{}{
+			"cert":        TestValueCert,
+			"key":         TestValueKey,
+			"server_cert": TestValueServerCert,
+			"server_key":  TestValueServerKey,
+			"ca":          TestValueCa,
+		}
+
+		config, err := NewConfigFromMapWithPathContext(configMap, TestValuePathContext)
+
+		req.NoError(err)
+		req.Equal(config.Cert, TestValueCert)
+		req.Equal(config.Key, TestValueKey)
+		req.Equal(config.ServerCert, TestValueServerCert)
+		req.Equal(config.ServerKey, TestValueServerKey)
+		req.Equal(config.CA, TestValueCa)
+	})
+
+	t.Run("errors on non-string cert", func(t *testing.T) {
+		req := require.New(t)
+
+		configMap := map[interface{}]interface{}{
+			"cert":        1,
+			"key":         TestValueKey,
+			"server_cert": TestValueServerCert,
+			"server_key":  TestValueServerKey,
+			"ca":          TestValueCa,
+		}
+
+		_, err := NewConfigFromMapWithPathContext(configMap, TestValuePathContext)
+
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMapStringErrorTemplate, TestValuePathContext + ".cert"))
+	})
+
+	t.Run("errors on non-string key", func(t *testing.T) {
+		req := require.New(t)
+
+		configMap := map[interface{}]interface{}{
+			"cert":        TestValueCert,
+			"key":         1,
+			"server_cert": TestValueServerCert,
+			"server_key":  TestValueServerKey,
+			"ca":          TestValueCa,
+		}
+
+		_, err := NewConfigFromMapWithPathContext(configMap, TestValuePathContext)
+
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMapStringErrorTemplate, TestValuePathContext + ".key"))
+	})
+
+	t.Run("errors on non-string server_cert", func(t *testing.T) {
+		req := require.New(t)
+
+		configMap := map[interface{}]interface{}{
+			"cert":        TestValueCert,
+			"key":         TestValueKey,
+			"server_cert": 1,
+			"server_key":  TestValueServerKey,
+			"ca":          TestValueCa,
+		}
+
+		_, err := NewConfigFromMapWithPathContext(configMap, TestValuePathContext)
+
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMapStringErrorTemplate, TestValuePathContext + ".server_cert"))
+	})
+
+	t.Run("errors on non-string server_key", func(t *testing.T) {
+		req := require.New(t)
+
+		configMap := map[interface{}]interface{}{
+			"cert":        TestValueCert,
+			"key":         TestValueKey,
+			"server_cert": TestValueServerCert,
+			"server_key":  1,
+			"ca":          TestValueCa,
+		}
+
+		_, err := NewConfigFromMapWithPathContext(configMap, TestValuePathContext)
+
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMapStringErrorTemplate, TestValuePathContext + ".server_key"))
+	})
+
+	t.Run("errors on non-string ca", func(t *testing.T) {
+		req := require.New(t)
+
+		configMap := map[interface{}]interface{}{
+			"cert":        TestValueCert,
+			"key":         TestValueKey,
+			"server_cert": TestValueServerCert,
+			"server_key":  TestValueServerKey,
+			"ca":          1,
+		}
+
+		_, err := NewConfigFromMapWithPathContext(configMap, TestValuePathContext)
+
+		req.Error(err)
+		req.Equal(err.Error(), fmt.Sprintf(TestValueMapStringErrorTemplate, TestValuePathContext + ".ca"))
+	})
+}

--- a/identity/identity/identity_test.go
+++ b/identity/identity/identity_test.go
@@ -66,7 +66,7 @@ func TestLoadIdentityWithPEM(t *testing.T) {
 		Bytes: certDer,
 	}
 
-	cfg := IdentityConfig{
+	cfg := Config{
 		Key:  "pem:" + string(pem.EncodeToMemory(keyPem)),
 		Cert: "pem:" + string(pem.EncodeToMemory(certPem)),
 	}
@@ -103,7 +103,7 @@ func TestLoadIdentityWithPEMChain(t *testing.T) {
 		Bytes: certDer,
 	}
 
-	cfg := IdentityConfig{
+	cfg := Config{
 		Key:  "pem:" + string(pem.EncodeToMemory(keyPem)),
 		Cert: "pem:" + string(pem.EncodeToMemory(certPem)) + string(pem.EncodeToMemory(parentPem)),
 	}
@@ -159,7 +159,7 @@ func TestLoadIdentityWithFile(t *testing.T) {
 	pem.Encode(keyFile, keyPem)
 	pem.Encode(certFile, certPem)
 
-	cfg := IdentityConfig{
+	cfg := Config{
 		Key:  "file://" + keyFile.Name(),
 		Cert: "file://" + certFile.Name(),
 	}


### PR DESCRIPTION
- tls.Configs from an identity can now refresh CAs
- identities can now produce a ref to their source identity config
- identity configs can now be used to alter in use certs/keys
- renames IdentityConfig to Config
- moves Config to new file with tests and helper functions
- fixes missing edge cases for non-file cert updates
- makes TokenId and Identity by embedding ID instead of declaring as a
  field
