### PR TITLE
adds ignore paths for validate delete

### DIFF
--- a/storage/boltz/testing.go
+++ b/storage/boltz/testing.go
@@ -125,9 +125,9 @@ func (ctx *BaseTestContext) Reload(entity Entity) error {
 	})
 }
 
-func (ctx *BaseTestContext) ValidateDeleted(id string) {
+func (ctx *BaseTestContext) ValidateDeleted(id string, ignorePaths ...string) {
 	err := ctx.GetDb().View(func(tx *bbolt.Tx) error {
-		return ValidateDeleted(tx, id)
+		return ValidateDeleted(tx, id, ignorePaths...)
 	})
 	ctx.NoError(err)
 }


### PR DESCRIPTION
Eventual events will store ids of entities being deleted which causes delete verification tests to fail even though they have passed.