### PR TITLE
adds a specific type for reference errors

### DIFF
--- a/storage/boltz/crud_test.go
+++ b/storage/boltz/crud_test.go
@@ -816,8 +816,10 @@ func (test *crudTest) testFkIndex(t *testing.T) {
 		return test.empStore.DeleteById(ctx, employee2.Id)
 	})
 	empIdList := test.sortedIdList(employee1, employee3, employee4)
-	test.EqualError(err, fmt.Sprintf("cannot delete employees with id %v is referenced by employees with id %v, field manager",
-		employee2.Id, empIdList[0]))
+	test.EqualError(err, fmt.Sprintf("cannot delete employees with id %v is referenced by employees with id(s) %v, field manager",
+		employee2.Id, []string{empIdList[0]}))
+
+	test.True(IsReferenceExistsError(err))
 
 	err = test.db.Update(func(tx *bbolt.Tx) error {
 		ctx := NewMutateContext(tx)

--- a/storage/boltz/errors.go
+++ b/storage/boltz/errors.go
@@ -39,8 +39,40 @@ func (err *RecordNotFoundError) Error() string {
 	return fmt.Sprintf("%v with %v %v not found", err.EntityType, err.Field, err.Id)
 }
 
-var testError = &RecordNotFoundError{}
+var testErrorNotFound = &RecordNotFoundError{}
 
 func IsErrNotFoundErr(err error) bool {
-	return errors.As(err, &testError)
+	return errors.As(err, &testErrorNotFound)
+}
+
+func NewReferenceByIdsError(localType, localId, remoteType string, remoteIds []string, remoteField string) error {
+	return &ReferenceExistsError{
+		localType:   localType,
+		localId:     localId,
+		remoteType:  remoteType,
+		remoteIds:   remoteIds,
+		remoteField: remoteField,
+	}
+}
+
+func NewReferenceByIdError(localType, localId, remoteType, remoteId, remoteField string) error {
+	return NewReferenceByIdsError(localType, localId, remoteType, []string{remoteId}, remoteField)
+}
+
+var testErrorReferenceExists = &ReferenceExistsError{}
+
+type ReferenceExistsError struct {
+	localType   string
+	remoteType  string
+	remoteField string
+	localId     string
+	remoteIds   []string
+}
+
+func IsReferenceExistsError(err error) bool {
+	return errors.As(err, &testErrorReferenceExists)
+}
+
+func (err *ReferenceExistsError) Error() string {
+	return fmt.Sprintf("cannot delete %v with id %v is referenced by %v with id(s) %v, field %v", err.localType, err.localId, err.remoteType, err.remoteIds, err.remoteField)
 }

--- a/storage/boltz/indexes.go
+++ b/storage/boltz/indexes.go
@@ -807,9 +807,12 @@ func (index *fkDeleteConstraint) ProcessBeforeDelete(ctx *IndexingContext) {
 		rtSymbol := index.symbol.GetRuntimeSymbol()
 		if rtSymbol.OpenCursor(ctx.Tx(), ctx.RowId).IsValid() {
 			_, firstId := rtSymbol.Eval(ctx.Tx(), ctx.RowId)
-			ctx.ErrHolder.SetError(errors.Errorf("cannot delete %v with id %v is referenced by %v with id %v, field %v",
-				index.symbol.GetStore().GetEntityType(), string(ctx.RowId), index.fkSymbol.GetStore().GetEntityType(),
-				string(firstId), index.fkSymbol.GetName()))
+			ctx.ErrHolder.SetError(NewReferenceByIdError(
+				index.symbol.GetStore().GetEntityType(),
+				string(ctx.RowId),
+				index.fkSymbol.GetStore().GetEntityType(),
+				string(firstId),
+				index.fkSymbol.GetName()))
 		}
 	}
 }
@@ -926,9 +929,11 @@ func (index *fkDeleteCascadeConstraint) ProcessBeforeDelete(ctx *IndexingContext
 
 		if index.cascadeType == CascadeNone {
 			for cursor := targetStore.IterateValidIds(ctx.Tx(), filter); cursor.IsValid(); cursor.Next() {
-				ctx.ErrHolder.SetError(errors.Errorf("cannot delete %v with id %v is referenced by %v with id %v, field %v",
-					index.symbol.GetLinkedType().GetSingularEntityType(), string(ctx.RowId),
-					index.symbol.GetStore().GetSingularEntityType(), string(cursor.Current()),
+				ctx.ErrHolder.SetError(NewReferenceByIdError(
+					index.symbol.GetLinkedType().GetSingularEntityType(),
+					string(ctx.RowId),
+					index.symbol.GetStore().GetSingularEntityType(),
+					string(cursor.Current()),
 					index.symbol.GetName()))
 				return
 			}


### PR DESCRIPTION
Allows downstream consumers to inspect errors (similar to not found) and
present proper error signaling. A specific example is allowing REST APIs
to return 409 Conflicts instead of generic 500 internal server errors
without doing string comparisons.