### PR TITLE
adds unique index error type

### DIFF
--- a/storage/boltz/errors.go
+++ b/storage/boltz/errors.go
@@ -61,6 +61,8 @@ func NewReferenceByIdError(localType, localId, remoteType, remoteId, remoteField
 
 var testErrorReferenceExists = &ReferenceExistsError{}
 
+// ReferenceExistsError is an error returned when an operation cannot be completed due to a referential constraint.
+// Typically, when deleting an entity (called local) that is referenced by another entity (called the remote)
 type ReferenceExistsError struct {
 	LocalType   string
 	RemoteType  string
@@ -75,4 +77,21 @@ func IsReferenceExistsError(err error) bool {
 
 func (err *ReferenceExistsError) Error() string {
 	return fmt.Sprintf("cannot delete %v with id %v is referenced by %v with id(s) %v, field %v", err.LocalType, err.LocalId, err.RemoteType, err.RemoteIds, err.RemoteField)
+}
+
+var testUniqueIndexDuplicateError = &UniqueIndexDuplicateError{}
+
+// UniqueIndexDuplicateError is an error that is returned when a unique index is violated due to duplicate values
+type UniqueIndexDuplicateError struct {
+	Field      string
+	Value      string
+	EntityType string
+}
+
+func IsUniqueIndexDuplicateError(err error) bool {
+	return errors.As(err, &testUniqueIndexDuplicateError)
+}
+
+func (err *UniqueIndexDuplicateError) Error() string {
+	return fmt.Sprintf("duplicate value '%v' in unique index on %v store", err.Value, err.EntityType)
 }

--- a/storage/boltz/indexes.go
+++ b/storage/boltz/indexes.go
@@ -308,8 +308,11 @@ func (index *uniqueIndex) ProcessAfterUpdate(ctx *IndexingContext) {
 
 		if len(newValue) > 0 {
 			if indexBucket.Get(newValue) != nil {
-				ctx.ErrHolder.SetError(errors.Errorf("duplicate value '%v' in unique index on %v store",
-					string(newValue), index.symbol.GetStore().GetEntityType()))
+				ctx.ErrHolder.SetError(&UniqueIndexDuplicateError{
+					Field:      index.symbol.GetName(),
+					Value:      string(newValue),
+					EntityType: index.symbol.GetStore().GetEntityType(),
+				})
 			} else {
 				ctx.ErrHolder.SetError(indexBucket.PutValue(newValue, ctx.RowId).Err)
 			}


### PR DESCRIPTION
Allows upstream API layers to detect error type instead of doing string
matching to provide presentation API specific errors. An example would
be a REST API wanting to provided a 400 BAD REQUEST with a field
specific error.