### PR TITLE
moves to v2.0.0 of cmap w/ generics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/michaelquigley/pfxlog v0.6.9
 	github.com/miekg/pkcs11 v1.1.1
 	github.com/mitchellh/go-ps v1.0.0
-	github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6
+	github.com/orcaman/concurrent-map/v2 v2.0.0
 	github.com/parallaxsecond/parsec-client-go v0.0.0-20210416104105-e2d188152601
 	github.com/pkg/errors v0.9.1
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
 github.com/onsi/gomega v1.13.0 h1:7lLHu94wT9Ij0o6EWWclhu0aOh32VxhkwEJvzuWPeak=
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
-github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6 h1:lNCW6THrCKBiJBpz8kbVGjC7MgdCGKwuvBgc7LoD6sw=
-github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
+github.com/orcaman/concurrent-map/v2 v2.0.0 h1:iSMwuBQvQ1nX5i9gYuGMiSy0fjWHmazdjF+NdSO9JzI=
+github.com/orcaman/concurrent-map/v2 v2.0.0/go.mod h1:9Eq3TG2oBe5FirmYWQfYO5iH1q0Jv47PLaNK++uCdOM=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/foundation/metrics/metrics_pb"
-	"github.com/orcaman/concurrent-map"
+	cmap "github.com/orcaman/concurrent-map/v2"
 	"github.com/pkg/errors"
 	"github.com/rcrowley/go-metrics"
 	"reflect"
@@ -50,14 +50,14 @@ func NewRegistry(sourceId string, tags map[string]string) Registry {
 	return &registryImpl{
 		sourceId:  sourceId,
 		tags:      tags,
-		metricMap: cmap.New(),
+		metricMap: cmap.New[any](),
 	}
 }
 
 type registryImpl struct {
 	sourceId  string
 	tags      map[string]string
-	metricMap cmap.ConcurrentMap
+	metricMap cmap.ConcurrentMap[any]
 }
 
 func (registry *registryImpl) dispose(name string) {

--- a/metrics/registry_test.go
+++ b/metrics/registry_test.go
@@ -2,7 +2,7 @@ package metrics
 
 import (
 	"github.com/openziti/foundation/metrics/metrics_pb"
-	cmap "github.com/orcaman/concurrent-map"
+	cmap "github.com/orcaman/concurrent-map/v2"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
@@ -20,7 +20,7 @@ func setUpTest(t *testing.T) *testData {
 		registry: &usageRegistryImpl{
 			registryImpl: registryImpl{
 				sourceId:  t.Name(),
-				metricMap: cmap.New(),
+				metricMap: cmap.New[any](),
 			},
 			intervalBucketChan: make(chan *bucketEvent, 1),
 		}}

--- a/metrics/usage_registry.go
+++ b/metrics/usage_registry.go
@@ -3,7 +3,7 @@ package metrics
 import (
 	"fmt"
 	"github.com/openziti/foundation/metrics/metrics_pb"
-	cmap "github.com/orcaman/concurrent-map"
+	cmap "github.com/orcaman/concurrent-map/v2"
 	"reflect"
 	"time"
 )
@@ -22,7 +22,7 @@ func NewUsageRegistry(sourceId string, tags map[string]string, closeNotify <-cha
 		registryImpl: registryImpl{
 			sourceId:  sourceId,
 			tags:      tags,
-			metricMap: cmap.New(),
+			metricMap: cmap.New[any](),
 		},
 		intervalBucketChan: make(chan *bucketEvent, 16),
 		closeNotify:        closeNotify,


### PR DESCRIPTION
I want to use cmap v2.0.0 (w/ generics). The v2 is because the API is not backward compat anymore. We could have both versions in OpenZiti (foundation -> ziti) however I figure it is probably best to start working from the bottom up and move everything over to v2.0.0.

In this repo, `any` was used because the registry maps don't have a single interface that is both `Metric` and `refCounted`.
