### PR TITLE
Add actions to dependabot. Use latest go version. Use latest golangci-lint.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,12 @@ updates:
       update-types:
         - "minor"
         - "patch"
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  groups:
+    all:
+      applies-to: version-updates

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,15 +11,15 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.19
-      - uses: actions/checkout@v3
+          go-version: stable
+      - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.49
+          version: latest
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/goroutines/pool.go
+++ b/goroutines/pool.go
@@ -128,6 +128,7 @@ func (self *pool) QueueWithTimeout(work func(), timeout time.Duration) error {
 }
 
 func (self *pool) queueImpl(work func(), timeoutC <-chan time.Time) error {
+	self.ensureNoStarvation()
 	select {
 	case self.queue <- work:
 		self.incrQueueSize()


### PR DESCRIPTION
Also, one-liner fix for go-routine pools with 0 queue length
