### PR TITLE
Use crypto/fips140 for FIPS detection

### DIFF
--- a/tlz/fips.go
+++ b/tlz/fips.go
@@ -1,13 +1,12 @@
-//go:build goexperiment.opensslcrypto && requirefips
-
 package tlz
 
-import (
-    "crypto/boring"
-    _ "crypto/tls/fipsonly"
-)
+import "crypto/fips140"
 
-// returns true if the OpenSSL FIPS provider is active at runtime
+// FipsEnabled reports whether the cryptography libraries are operating in FIPS
+// 140-3 mode.
+//
+// Note that this also works with the Microsoft build of Go when using an OpenSSL backend.
+// In that case, it reports whether the OpenSSL library is operating in FIPS mode.
 func FipsEnabled() bool {
-    return boring.Enabled()
+	return fips140.Enabled()
 }

--- a/tlz/nofips.go
+++ b/tlz/nofips.go
@@ -1,8 +1,0 @@
-//go:build !goexperiment.opensslcrypto && !requirefips
-
-package tlz
-
-// returns false if the binary was built with FIPS mode disabled
-func FipsEnabled() bool {
-    return false
-}


### PR DESCRIPTION
Hi! Microsoft build of Go maintainer here.

Using the `goexperiment.opensslcrypto` build tag is not necessary anymore. Since Go 1.25 you can use the `crypto/fips140.Enabled()` function, which is part of the standard library.