### PR TITLE
Add slog logging core (foundation/v2/logging) for upstream libraries

### DIFF
--- a/logging/chain.go
+++ b/logging/chain.go
@@ -1,0 +1,103 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+)
+
+// boundHandler carries a set of attrs that get prepended to every record
+// flowing through it, then delegates to its parent. WithAttrs never mutates
+// the receiver; it returns a new boundHandler whose attrs are the receiver's
+// combined with the additional ones and whose parent is the receiver's parent
+// (not the receiver itself). The effect on a chain of slog.Logger.With calls
+// is that they produce sibling boundHandlers at the same chain depth rather
+// than stacking wrapper-on-wrapper, which would grow the chain on every call.
+type boundHandler struct {
+	parent slog.Handler
+	attrs  []slog.Attr
+}
+
+func (h *boundHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.parent.Enabled(ctx, level)
+}
+
+func (h *boundHandler) Handle(ctx context.Context, r slog.Record) error {
+	r2 := slog.NewRecord(r.Time, r.Level, r.Message, r.PC)
+	r2.AddAttrs(h.attrs...)
+	r.Attrs(func(a slog.Attr) bool {
+		r2.AddAttrs(a)
+		return true
+	})
+	return h.parent.Handle(ctx, r2)
+}
+
+func (h *boundHandler) WithAttrs(more []slog.Attr) slog.Handler {
+	if len(more) == 0 {
+		return h
+	}
+	combined := make([]slog.Attr, 0, len(h.attrs)+len(more))
+	combined = append(combined, h.attrs...)
+	combined = append(combined, more...)
+	return &boundHandler{parent: h.parent, attrs: combined}
+}
+
+func (h *boundHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return &groupedHandler{parent: h, name: name}
+}
+
+// groupedHandler wraps every record's attrs in slog.Group(name, ...) before
+// delegating to its parent. A subsequent WithAttrs creates a boundHandler
+// whose parent is this groupedHandler, so the attrs land inside the group.
+type groupedHandler struct {
+	parent slog.Handler
+	name   string
+}
+
+func (h *groupedHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.parent.Enabled(ctx, level)
+}
+
+func (h *groupedHandler) Handle(ctx context.Context, r slog.Record) error {
+	var items []any
+	r.Attrs(func(a slog.Attr) bool {
+		items = append(items, a)
+		return true
+	})
+	r2 := slog.NewRecord(r.Time, r.Level, r.Message, r.PC)
+	r2.AddAttrs(slog.Group(h.name, items...))
+	return h.parent.Handle(ctx, r2)
+}
+
+func (h *groupedHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	return &boundHandler{parent: h, attrs: slices.Clone(attrs)}
+}
+
+func (h *groupedHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return &groupedHandler{parent: h, name: name}
+}

--- a/logging/chain_test.go
+++ b/logging/chain_test.go
@@ -1,0 +1,244 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// runWithLogger builds a fresh AsyncHandler over a JSON downstream, lets the
+// caller emit one record through a slog.Logger backed by the handler, then
+// closes the handler, waits for the drain, and returns the parsed JSON. Time
+// and level keys are filtered out so tests can assert on shape alone.
+func runWithLogger(t *testing.T, f func(*slog.Logger)) map[string]any {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	downstream := slog.NewJSONHandler(buf, &slog.HandlerOptions{
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey || a.Key == slog.LevelKey {
+				return slog.Attr{}
+			}
+			return a
+		},
+	})
+	h, err := NewAsyncHandler(downstream, DefaultOptions())
+	require.NoError(t, err)
+
+	f(slog.New(h))
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+
+	line := strings.TrimSpace(buf.String())
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &got), "raw=%q", line)
+	return got
+}
+
+func TestChainWithAttrs(t *testing.T) {
+	got := runWithLogger(t, func(l *slog.Logger) {
+		l.With("a", 1).Info("msg", "b", 2)
+	})
+	require.Equal(t, "msg", got["msg"])
+	require.Equal(t, float64(1), got["a"])
+	require.Equal(t, float64(2), got["b"])
+}
+
+func TestChainWithGroup(t *testing.T) {
+	got := runWithLogger(t, func(l *slog.Logger) {
+		l.WithGroup("g").Info("msg", "a", 1)
+	})
+	require.Equal(t, "msg", got["msg"])
+	g, ok := got["g"].(map[string]any)
+	require.True(t, ok, "g should be a nested object, got %T", got["g"])
+	require.Equal(t, float64(1), g["a"])
+}
+
+// TestChainBoundAttrsBeforeGroup: With("a",1).WithGroup("g").With("b",2)
+//
+//	.Info("msg","c",3)  ->  {msg, a:1, g:{b:2, c:3}}
+func TestChainBoundAttrsBeforeGroup(t *testing.T) {
+	got := runWithLogger(t, func(l *slog.Logger) {
+		l.With("a", 1).WithGroup("g").With("b", 2).Info("msg", "c", 3)
+	})
+	require.Equal(t, "msg", got["msg"])
+	require.Equal(t, float64(1), got["a"])
+	g, ok := got["g"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, float64(2), g["b"])
+	require.Equal(t, float64(3), g["c"])
+}
+
+// TestChainAttrsInsideGroup: WithGroup("g").With("a",1).Info("msg","b",2)
+//
+//	->  {msg, g:{a:1, b:2}}  (the .With after WithGroup lands inside the group)
+func TestChainAttrsInsideGroup(t *testing.T) {
+	got := runWithLogger(t, func(l *slog.Logger) {
+		l.WithGroup("g").With("a", 1).Info("msg", "b", 2)
+	})
+	require.Equal(t, "msg", got["msg"])
+	g, ok := got["g"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, float64(1), g["a"])
+	require.Equal(t, float64(2), g["b"])
+	require.NotContains(t, got, "a", "a should be inside g, not at the root")
+}
+
+// TestChainNestedGroups: WithGroup("a").WithGroup("b").Info("msg","c",3)
+//
+//	->  {msg, a:{b:{c:3}}}
+func TestChainNestedGroups(t *testing.T) {
+	got := runWithLogger(t, func(l *slog.Logger) {
+		l.WithGroup("a").WithGroup("b").Info("msg", "c", 3)
+	})
+	require.Equal(t, "msg", got["msg"])
+	a, ok := got["a"].(map[string]any)
+	require.True(t, ok)
+	b, ok := a["b"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, float64(3), b["c"])
+}
+
+// TestChainWithAttrsDoesNotNestWrappers proves that two consecutive WithAttrs
+// calls on AsyncHandler -> boundHandler produce a single boundHandler whose
+// parent is still AsyncHandler (a sibling at the same chain depth), not a
+// new boundHandler wrapping the first one. This keeps chain depth bounded
+// when slog.Logger.With is called repeatedly.
+func TestChainWithAttrsDoesNotNestWrappers(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	defer func() { _ = h.Close(); <-h.drainDone }()
+
+	first := h.WithAttrs([]slog.Attr{slog.Int("a", 1)})
+	second := first.WithAttrs([]slog.Attr{slog.Int("b", 2)})
+
+	bh, ok := second.(*boundHandler)
+	require.True(t, ok, "expected *boundHandler, got %T", second)
+	require.Equal(t, h, bh.parent, "parent should still be AsyncHandler, not the first boundHandler")
+	require.Len(t, bh.attrs, 2)
+	require.Equal(t, "a", bh.attrs[0].Key)
+	require.Equal(t, "b", bh.attrs[1].Key)
+}
+
+// TestChainWithGroupEmptyIsNoop proves WithGroup("") returns the receiver
+// unchanged on each of the three handler types.
+func TestChainWithGroupEmptyIsNoop(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	defer func() { _ = h.Close(); <-h.drainDone }()
+
+	require.Same(t, h, h.WithGroup(""), "AsyncHandler.WithGroup(\"\") should return receiver")
+
+	bh := h.WithAttrs([]slog.Attr{slog.Int("a", 1)}).(*boundHandler)
+	require.Same(t, bh, bh.WithGroup("").(*boundHandler), "boundHandler.WithGroup(\"\") should return receiver")
+
+	gh := h.WithGroup("g").(*groupedHandler)
+	require.Same(t, gh, gh.WithGroup("").(*groupedHandler), "groupedHandler.WithGroup(\"\") should return receiver")
+}
+
+// TestChainWithAttrsEmptyIsNoop proves WithAttrs(nil) returns the receiver
+// on each of the three handler types, so slog.Logger.With() with no args
+// allocates nothing.
+func TestChainWithAttrsEmptyIsNoop(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	defer func() { _ = h.Close(); <-h.drainDone }()
+
+	require.Same(t, h, h.WithAttrs(nil))
+
+	bh := h.WithAttrs([]slog.Attr{slog.Int("a", 1)}).(*boundHandler)
+	require.Same(t, bh, bh.WithAttrs(nil).(*boundHandler))
+
+	gh := h.WithGroup("g").(*groupedHandler)
+	require.Same(t, gh, gh.WithAttrs(nil).(*groupedHandler))
+}
+
+// TestChainSiblingLoggersDoNotLeakAttrs proves that deriving a child logger
+// inside a loop and reusing the parent logger after the loop is safe: the
+// parent's attrs are not contaminated by the children's additions. This is a
+// common pattern (a parent logger plus per-iteration enrichment) and the
+// extends-in-place optimization in boundHandler.WithAttrs must not break it.
+func TestChainSiblingLoggersDoNotLeakAttrs(t *testing.T) {
+	buf := &bytes.Buffer{}
+	downstream := slog.NewJSONHandler(buf, &slog.HandlerOptions{
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey || a.Key == slog.LevelKey {
+				return slog.Attr{}
+			}
+			return a
+		},
+	})
+	h, err := NewAsyncHandler(downstream, DefaultOptions())
+	require.NoError(t, err)
+
+	parent := slog.New(h).With("scope", "outer")
+	parent.Info("before-loop")
+	for _, v := range []int{1, 2, 3} {
+		parent.With("v", v).Info("in-loop")
+	}
+	parent.Info("after-loop")
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+
+	var lines []map[string]any
+	for _, raw := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		var m map[string]any
+		require.NoError(t, json.Unmarshal([]byte(raw), &m))
+		lines = append(lines, m)
+	}
+	require.Len(t, lines, 5)
+
+	require.Equal(t, "before-loop", lines[0]["msg"])
+	require.Equal(t, "outer", lines[0]["scope"])
+	require.NotContains(t, lines[0], "v")
+
+	for i := 1; i <= 3; i++ {
+		require.Equal(t, "in-loop", lines[i]["msg"])
+		require.Equal(t, "outer", lines[i]["scope"])
+		require.Equal(t, float64(i), lines[i]["v"])
+	}
+
+	require.Equal(t, "after-loop", lines[4]["msg"])
+	require.Equal(t, "outer", lines[4]["scope"])
+	require.NotContains(t, lines[4], "v", "parent logger must not have inherited a child's attr")
+}
+
+// TestChainEnabledDelegates proves Enabled on chain wrappers reaches
+// AsyncHandler, which currently returns true.
+func TestChainEnabledDelegates(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	defer func() { _ = h.Close(); <-h.drainDone }()
+
+	bh := h.WithAttrs([]slog.Attr{slog.Int("a", 1)})
+	gh := h.WithGroup("g")
+
+	require.True(t, bh.Enabled(context.Background(), slog.LevelDebug))
+	require.True(t, gh.Enabled(context.Background(), slog.LevelDebug))
+}

--- a/logging/handler.go
+++ b/logging/handler.go
@@ -1,0 +1,311 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// AsyncHandler is a bounded, async slog.Handler that hands records to a single
+// drain goroutine and onto a downstream handler. Records at or above the
+// configured BlockThreshold block when the queue is full; records below it
+// drop and are counted toward a periodic summary line.
+//
+// AsyncHandler is the root of the slog handler chain: WithAttrs returns a
+// boundHandler that prepends bound attrs to records, and WithGroup returns a
+// groupedHandler that wraps record attrs in slog.Group(name, ...). Both
+// wrappers delegate back to AsyncHandler.Handle, which is where the queueing
+// and drain dispatch live.
+type AsyncHandler struct {
+	opts         AsyncOptions
+	downstream   slog.Handler
+	queue        chan queuedRecord
+	closeNotify  chan struct{}
+	drainDone    chan struct{}
+	closed       atomic.Bool
+	downstreamMu sync.Mutex
+	dropCounts   [7]atomic.Int64
+	drainErrors  atomic.Int64
+	// windowStart is the start of the current summary window. It is only
+	// accessed by the drain goroutine after the handler is constructed.
+	windowStart time.Time
+}
+
+// queuedRecord carries the originating call's context alongside the record so
+// downstream handlers that consult ctx values (tracing, OTel) see them across
+// the async hop.
+type queuedRecord struct {
+	ctx    context.Context
+	record slog.Record
+}
+
+// NewAsyncHandler returns an AsyncHandler that drains records onto downstream.
+// It validates opts and starts the drain goroutine; on validation failure it
+// returns an error and no resources are leaked.
+func NewAsyncHandler(downstream slog.Handler, opts AsyncOptions) (*AsyncHandler, error) {
+	if downstream == nil {
+		return nil, errors.New("downstream handler must not be nil")
+	}
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+	h := &AsyncHandler{
+		opts:        opts,
+		downstream:  downstream,
+		queue:       make(chan queuedRecord, opts.QueueSize),
+		closeNotify: make(chan struct{}),
+		drainDone:   make(chan struct{}),
+		windowStart: time.Now(),
+	}
+	go h.drain()
+	return h, nil
+}
+
+// Enabled returns true. AsyncHandler does no level gating itself; records are
+// gated before they reach it. Direct slog callers go through the named-logger
+// registry's handler, whose Enabled checks the per-name override or live
+// global level, and bridged logrus records are pre-filtered by logrus's own
+// level check (see doc/design/logging-refactor.md). A second check here would
+// be a redundant atomic load on every call.
+func (h *AsyncHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+// Handle enqueues r for the drain goroutine. Records at or above
+// BlockThreshold block when the queue is full (with a closeNotify escape so
+// shutdown can't deadlock); records below BlockThreshold drop and increment
+// the per-level drop counter.
+func (h *AsyncHandler) Handle(ctx context.Context, r slog.Record) error {
+	if h.closed.Load() {
+		return nil
+	}
+	qr := queuedRecord{ctx: ctx, record: r}
+	if r.Level >= h.opts.BlockThreshold {
+		select {
+		case h.queue <- qr:
+		case <-h.closeNotify:
+			// shutdown; best-effort drop
+		}
+	} else {
+		select {
+		case h.queue <- qr:
+		default:
+			h.dropCounts[dropIdx(r.Level)].Add(1)
+		}
+	}
+	return nil
+}
+
+// WithAttrs returns a child handler that prepends the given attrs to every
+// record it sees before forwarding to AsyncHandler. An empty attrs slice
+// returns the receiver unchanged so slog.Logger.With() with no args is free.
+func (h *AsyncHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	return &boundHandler{parent: h, attrs: slices.Clone(attrs)}
+}
+
+// WithGroup returns a child handler that wraps every record's attrs in
+// slog.Group(name, ...) before forwarding. An empty group name returns the
+// receiver unchanged, matching slog's convention.
+func (h *AsyncHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return &groupedHandler{parent: h, name: name}
+}
+
+// Close initiates shutdown and returns immediately. The drain goroutine
+// finishes processing whatever is already enqueued, emits a final drop
+// summary if any drops occurred, then exits and closes the drainDone channel.
+// Calling Close more than once is a no-op.
+//
+// A producer that races with Close may still successfully enqueue a record
+// that the drain never sees; per the design, logging during shutdown is
+// best-effort. Records routed through SyncEmit are durable because they
+// bypass the queue and write synchronously.
+func (h *AsyncHandler) Close() error {
+	if !h.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	close(h.closeNotify)
+	return nil
+}
+
+// SyncEmit flushes the records currently queued, then writes r through the
+// downstream handler synchronously on the caller's goroutine. It exists so
+// that fatal/panic records reach the downstream before the process exits, and
+// flushing first means the buffered context leading up to the fatal/panic
+// (the very records an operator wants in a post-mortem) lands ahead of it
+// rather than being lost when the process exits out from under the drain.
+//
+// The flush is bounded and non-blocking, so a producer still enqueuing cannot
+// make it spin and the drain goroutine cannot deadlock it. A single record the
+// drain has already pulled but not yet written may still land after r; ordering
+// on the exit path is best-effort, not exact.
+func (h *AsyncHandler) SyncEmit(ctx context.Context, r slog.Record) error {
+	h.downstreamMu.Lock()
+	defer h.downstreamMu.Unlock()
+	h.flushQueuedLocked()
+	return h.downstream.Handle(ctx, r)
+}
+
+// flushQueuedLocked drains the records sitting in the queue through the
+// downstream handler. The caller must hold downstreamMu. It is bounded by the
+// queue capacity and stops at the first empty receive, so a producer still
+// enqueuing cannot make it spin, and the drain goroutine (which may be parked
+// on downstreamMu) cannot deadlock it. Records the concurrent drain pulls
+// first are written by the drain; the rest are written here, all under the
+// same mutex so no downstream.Handle calls interleave.
+func (h *AsyncHandler) flushQueuedLocked() {
+	for i := cap(h.queue); i > 0; i-- {
+		select {
+		case qr := <-h.queue:
+			h.handleLocked(qr.ctx, qr.record)
+		default:
+			return
+		}
+	}
+}
+
+// drain is the single goroutine that pulls records off the queue and calls
+// the downstream handler. It also emits the periodic drop-summary record on
+// the summary ticker, and on shutdown does a final-flush pass through any
+// remaining queued records plus a final summary.
+func (h *AsyncHandler) drain() {
+	defer close(h.drainDone)
+	ticker := time.NewTicker(h.opts.SummaryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case qr := <-h.queue:
+			h.dispatch(qr.ctx, qr.record)
+		case <-ticker.C:
+			h.emitSummaryIfAny()
+		case <-h.closeNotify:
+			// final flush: drain any records that beat the close-notify
+			// reception, then emit a final summary if anything was dropped.
+			for {
+				select {
+				case qr := <-h.queue:
+					h.dispatch(qr.ctx, qr.record)
+				default:
+					h.emitSummaryIfAny()
+					return
+				}
+			}
+		}
+	}
+}
+
+// dispatch hands one record to the downstream handler under downstreamMu, the
+// same mutex SyncEmit takes, so the downstream handler does not need to be
+// concurrency-safe on its own.
+func (h *AsyncHandler) dispatch(ctx context.Context, r slog.Record) {
+	h.downstreamMu.Lock()
+	defer h.downstreamMu.Unlock()
+	h.handleLocked(ctx, r)
+}
+
+// handleLocked hands one record to the downstream handler, counting and
+// reporting a downstream error. The caller must hold downstreamMu. On error it
+// bumps drainErrors and writes once to os.Stderr, bypassing slog to avoid
+// recursion if the downstream handler is the thing failing.
+func (h *AsyncHandler) handleLocked(ctx context.Context, r slog.Record) {
+	if err := h.downstream.Handle(ctx, r); err != nil {
+		h.drainErrors.Add(1)
+		fmt.Fprintf(os.Stderr, "logging: downstream handler error: %v\n", err)
+	}
+}
+
+// emitSummaryIfAny snapshots and zeroes the drop and drain-error counters,
+// and if anything was non-zero emits a single summary record. Runs only from
+// the drain goroutine.
+func (h *AsyncHandler) emitSummaryIfAny() {
+	var counts [7]int64
+	anything := false
+	for i := range h.dropCounts {
+		c := h.dropCounts[i].Swap(0)
+		counts[i] = c
+		if c > 0 {
+			anything = true
+		}
+	}
+	errs := h.drainErrors.Swap(0)
+	if errs > 0 {
+		anything = true
+	}
+	if !anything {
+		return
+	}
+
+	now := time.Now()
+	since := h.windowStart
+	h.windowStart = now
+
+	r := slog.NewRecord(now, slog.LevelWarn, "logging queue full, message drop summary", 0)
+	for i, c := range counts {
+		if c > 0 {
+			r.AddAttrs(slog.Int64(canonicalLevelNames[i], c))
+		}
+	}
+	if errs > 0 {
+		r.AddAttrs(slog.Int64("drain_errors", errs))
+	}
+	r.AddAttrs(slog.Time("since", since))
+
+	h.downstreamMu.Lock()
+	_ = h.downstream.Handle(context.Background(), r)
+	h.downstreamMu.Unlock()
+}
+
+// canonicalLevelNames maps the drop-counter index to its canonical lowercase
+// level name, used as the attr key in the summary record.
+var canonicalLevelNames = [7]string{"trace", "debug", "info", "warn", "error", "fatal", "panic"}
+
+// dropIdx maps a slog.Level to its drop-counter bucket. Non-canonical levels
+// (e.g. slog.LevelDebug+1) bucket into the canonical level whose value they
+// most recently exceeded, so every record contributes to exactly one bucket.
+func dropIdx(l slog.Level) int {
+	switch {
+	case l < slog.LevelDebug:
+		return 0 // trace
+	case l < slog.LevelInfo:
+		return 1 // debug
+	case l < slog.LevelWarn:
+		return 2 // info
+	case l < slog.LevelError:
+		return 3 // warn
+	case l < LevelFatal:
+		return 4 // error
+	case l < LevelPanic:
+		return 5 // fatal
+	default:
+		return 6 // panic
+	}
+}

--- a/logging/handler_test.go
+++ b/logging/handler_test.go
@@ -1,0 +1,457 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingHandler captures every record passed to Handle so tests can
+// inspect what made it through the async sink.
+type recordingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r)
+	return nil
+}
+func (h *recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *recordingHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *recordingHandler) count() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.records)
+}
+
+func (h *recordingHandler) snapshot() []slog.Record {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]slog.Record(nil), h.records...)
+}
+
+// blockingHandler holds Handle until release is closed, signaling the first
+// entry into Handle via entered. It's used to deterministically park the
+// drain inside a downstream call so the queue fills up.
+type blockingHandler struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+	inner   *recordingHandler
+}
+
+func newBlockingHandler() *blockingHandler {
+	return &blockingHandler{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+		inner:   &recordingHandler{},
+	}
+}
+
+func (h *blockingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *blockingHandler) Handle(ctx context.Context, r slog.Record) error {
+	h.once.Do(func() { close(h.entered) })
+	<-h.release
+	return h.inner.Handle(ctx, r)
+}
+func (h *blockingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *blockingHandler) WithGroup(string) slog.Handler      { return h }
+
+// erroringHandler returns a fixed error from every Handle call. Used to
+// exercise the drain's error-counting path.
+type erroringHandler struct {
+	err   error
+	count atomic.Int64
+}
+
+func (h *erroringHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *erroringHandler) Handle(context.Context, slog.Record) error {
+	h.count.Add(1)
+	return h.err
+}
+func (h *erroringHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *erroringHandler) WithGroup(string) slog.Handler      { return h }
+
+func makeRecord(level slog.Level, msg string) slog.Record {
+	return slog.NewRecord(time.Now(), level, msg, 0)
+}
+
+func TestNewAsyncHandlerValidatesOptions(t *testing.T) {
+	rec := &recordingHandler{}
+	_, err := NewAsyncHandler(rec, AsyncOptions{}) // zero values invalid
+	require.Error(t, err)
+}
+
+func TestNewAsyncHandlerRejectsNilDownstream(t *testing.T) {
+	_, err := NewAsyncHandler(nil, DefaultOptions())
+	require.Error(t, err)
+}
+
+func TestAsyncHandlerNormalFlow(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, fmt.Sprintf("msg %d", i))))
+	}
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+
+	require.Equal(t, 5, rec.count())
+}
+
+// TestAsyncHandlerDropsSubThresholdWhenFull parks the drain inside the
+// downstream so the queue fills, then verifies that sub-threshold records
+// drop and bump the per-level counter without blocking the caller.
+func TestAsyncHandlerDropsSubThresholdWhenFull(t *testing.T) {
+	block := newBlockingHandler()
+	opts := DefaultOptions()
+	opts.QueueSize = 2
+	opts.SummaryInterval = time.Hour
+	h, err := NewAsyncHandler(block, opts)
+	require.NoError(t, err)
+
+	// Send one record; wait for the drain to enter the downstream.
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelDebug, "m1")))
+	<-block.entered
+
+	// Fill the queue (capacity 2).
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelDebug, "m2")))
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelDebug, "m3")))
+
+	// Sub-threshold records now drop without blocking.
+	for i := 0; i < 5; i++ {
+		require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelDebug, "dropped")))
+	}
+	require.Equal(t, int64(5), h.dropCounts[dropIdx(slog.LevelDebug)].Load())
+
+	// Release the downstream, close, and verify only the original three got
+	// through. Filter the close-flush drop-summary out of the count.
+	close(block.release)
+	require.NoError(t, h.Close())
+	<-h.drainDone
+
+	nonSummary := 0
+	for _, r := range block.inner.snapshot() {
+		if r.Message != "logging queue full, message drop summary" {
+			nonSummary++
+		}
+	}
+	require.Equal(t, 3, nonSummary)
+}
+
+// TestAsyncHandlerBlocksAtThreshold proves a record at the block threshold
+// parks Handle until the drain frees a slot, instead of dropping.
+func TestAsyncHandlerBlocksAtThreshold(t *testing.T) {
+	block := newBlockingHandler()
+	opts := DefaultOptions()
+	opts.QueueSize = 2
+	opts.SummaryInterval = time.Hour
+	h, err := NewAsyncHandler(block, opts)
+	require.NoError(t, err)
+
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, "m1")))
+	<-block.entered
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, "m2")))
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, "m3")))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelWarn, "warn1")))
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("Handle on Warn returned but should have blocked")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(block.release)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Handle on Warn never returned after the downstream was released")
+	}
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+	require.Equal(t, 4, block.inner.count())
+}
+
+// TestAsyncHandlerCloseUnblocksHandle proves a Handle call parked on the
+// blocking arm of select returns when Close fires, instead of deadlocking.
+func TestAsyncHandlerCloseUnblocksHandle(t *testing.T) {
+	block := newBlockingHandler()
+	defer close(block.release)
+	opts := DefaultOptions()
+	opts.QueueSize = 1
+	opts.SummaryInterval = time.Hour
+	h, err := NewAsyncHandler(block, opts)
+	require.NoError(t, err)
+
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, "m1")))
+	<-block.entered
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, "m2")))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = h.Handle(context.Background(), makeRecord(slog.LevelWarn, "warn"))
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("Handle should be blocked at this point")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	require.NoError(t, h.Close())
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not unblock Handle")
+	}
+}
+
+func TestAsyncHandlerCloseIdempotent(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	require.NoError(t, h.Close())
+	require.NoError(t, h.Close())
+}
+
+func TestAsyncHandlerHandleAfterCloseReturnsNil(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	require.NoError(t, h.Close())
+	<-h.drainDone
+
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, "after-close")))
+}
+
+// TestAsyncHandlerHandleRacingCloseNoPanic spawns many producers and a
+// concurrent Close. The handler must never panic and must drain cleanly.
+func TestAsyncHandlerHandleRacingCloseNoPanic(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				_ = h.Handle(context.Background(), makeRecord(slog.LevelInfo, "x"))
+			}
+		}()
+	}
+
+	time.Sleep(time.Millisecond) // let producers ramp
+	require.NoError(t, h.Close())
+	wg.Wait()
+	<-h.drainDone
+}
+
+// TestAsyncHandlerSummaryEmittedOnTick seeds the drop counters directly and
+// waits for the next ticker emission. Using direct counter seeding avoids
+// timing flakes around when the queue actually fills.
+func TestAsyncHandlerSummaryEmittedOnTick(t *testing.T) {
+	rec := &recordingHandler{}
+	opts := DefaultOptions()
+	opts.SummaryInterval = 20 * time.Millisecond
+	h, err := NewAsyncHandler(rec, opts)
+	require.NoError(t, err)
+
+	h.dropCounts[dropIdx(slog.LevelDebug)].Add(7)
+	h.dropCounts[dropIdx(slog.LevelInfo)].Add(3)
+
+	require.Eventually(t, func() bool { return rec.count() >= 1 }, time.Second, 5*time.Millisecond)
+
+	var summary *slog.Record
+	for _, r := range rec.snapshot() {
+		if r.Message == "logging queue full, message drop summary" {
+			r := r
+			summary = &r
+			break
+		}
+	}
+	require.NotNil(t, summary, "expected drop-summary record")
+
+	attrs := map[string]any{}
+	summary.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.Any()
+		return true
+	})
+	require.Equal(t, int64(7), attrs["debug"])
+	require.Equal(t, int64(3), attrs["info"])
+	require.NotContains(t, attrs, "trace", "zero-count levels must not appear")
+	require.Contains(t, attrs, "since")
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+}
+
+// TestSyncEmitDeliversSynchronously proves SyncEmit calls downstream.Handle
+// on the caller's goroutine, bypassing the queue.
+func TestSyncEmitDeliversSynchronously(t *testing.T) {
+	rec := &recordingHandler{}
+	h, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	defer func() {
+		_ = h.Close()
+		<-h.drainDone
+	}()
+
+	require.NoError(t, h.SyncEmit(context.Background(), makeRecord(LevelFatal, "fatal!")))
+	require.Equal(t, 1, rec.count())
+	require.Equal(t, "fatal!", rec.snapshot()[0].Message)
+}
+
+// TestSyncEmitSerializesWithDrain holds the drain inside the downstream, then
+// fires a SyncEmit. SyncEmit must wait for the in-flight drain dispatch to
+// finish (they share downstreamMu), so the queued record lands before the
+// SyncEmit record.
+func TestSyncEmitSerializesWithDrain(t *testing.T) {
+	block := newBlockingHandler()
+	h, err := NewAsyncHandler(block, DefaultOptions())
+	require.NoError(t, err)
+
+	require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, "queued")))
+	<-block.entered
+
+	syncDone := make(chan struct{})
+	go func() {
+		defer close(syncDone)
+		require.NoError(t, h.SyncEmit(context.Background(), makeRecord(LevelFatal, "sync")))
+	}()
+
+	// SyncEmit must be blocked waiting for downstreamMu held by the drain.
+	select {
+	case <-syncDone:
+		t.Fatal("SyncEmit returned while the drain was still inside Handle")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(block.release)
+	<-syncDone
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+
+	recs := block.inner.snapshot()
+	require.Equal(t, 2, len(recs))
+	require.Equal(t, "queued", recs[0].Message)
+	require.Equal(t, "sync", recs[1].Message)
+}
+
+// TestSyncEmitFlushesQueuedRecords proves SyncEmit drains the records already
+// sitting in the queue before writing its own record, so the buffered context
+// leading up to a fatal/panic survives a process exit that happens right after
+// the call. The drain goroutine is stopped first (Close, then drainDone) so the
+// flush runs in isolation with no concurrent consumer racing for the queue;
+// records are staged directly because Handle no-ops post-Close.
+func TestSyncEmitFlushesQueuedRecords(t *testing.T) {
+	rec := &recordingHandler{}
+	opts := DefaultOptions()
+	opts.QueueSize = 8
+	h, err := NewAsyncHandler(rec, opts)
+	require.NoError(t, err)
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+	require.Equal(t, 0, rec.count(), "no records should have been written before staging")
+
+	h.queue <- queuedRecord{ctx: context.Background(), record: makeRecord(slog.LevelInfo, "q1")}
+	h.queue <- queuedRecord{ctx: context.Background(), record: makeRecord(slog.LevelWarn, "q2")}
+
+	require.NoError(t, h.SyncEmit(context.Background(), makeRecord(LevelFatal, "fatal")))
+
+	recs := rec.snapshot()
+	got := make([]string, len(recs))
+	for i, r := range recs {
+		got[i] = r.Message
+	}
+	require.Equal(t, []string{"q1", "q2", "fatal"}, got)
+}
+
+// TestAsyncHandlerCountsDrainErrors emits records into a handler that errors
+// on every call and verifies the drain counts the errors and survives. The
+// assertions run before Close so the close-flush summary doesn't perturb
+// the error counter (the summary is itself sent through the downstream and
+// would otherwise add one more error).
+func TestAsyncHandlerCountsDrainErrors(t *testing.T) {
+	errH := &erroringHandler{err: errors.New("boom")}
+	opts := DefaultOptions()
+	opts.SummaryInterval = time.Hour
+	h, err := NewAsyncHandler(errH, opts)
+	require.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, h.Handle(context.Background(), makeRecord(slog.LevelInfo, "x")))
+	}
+
+	require.Eventually(t, func() bool { return errH.count.Load() == 3 }, time.Second, time.Millisecond)
+	require.Equal(t, int64(3), h.drainErrors.Load())
+
+	require.NoError(t, h.Close())
+	<-h.drainDone
+}
+
+func TestDropIdxBucketing(t *testing.T) {
+	tests := []struct {
+		level slog.Level
+		want  int
+	}{
+		{LevelTrace, 0},
+		{LevelTrace - 1, 0},
+		{slog.LevelDebug, 1},
+		{slog.LevelDebug + 1, 1},
+		{slog.LevelInfo, 2},
+		{slog.LevelWarn, 3},
+		{slog.LevelError, 4},
+		{LevelFatal, 5},
+		{LevelPanic, 6},
+		{LevelPanic + 100, 6},
+	}
+	for _, tt := range tests {
+		t.Run(LevelName(tt.level), func(t *testing.T) {
+			require.Equal(t, tt.want, dropIdx(tt.level))
+		})
+	}
+}

--- a/logging/levels.go
+++ b/logging/levels.go
@@ -1,0 +1,85 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+// Package logging is the async slog sink that ziti's logging refactor lands on.
+// It owns the seven canonical log levels (trace through panic), the bounded
+// AsyncHandler, and the SyncEmit path used for fatal/panic durability.
+package logging
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Custom slog.Level values extending slog's four standard levels (Debug=-4,
+// Info=0, Warn=4, Error=8) with Trace below Debug and Fatal and Panic above
+// Error. Together these cover the seven canonical level names ziti carries on
+// the agent IPC wire.
+const (
+	LevelTrace slog.Level = -8
+	LevelFatal slog.Level = 12
+	LevelPanic slog.Level = 16
+)
+
+// LevelName returns the canonical lowercase name for a slog.Level on the wire.
+// All seven canonical levels (trace, debug, info, warn, error, fatal, panic)
+// map to their canonical names. Non-canonical values (e.g. slog.LevelDebug+1)
+// fall back to a lowercased slog.Level.String(); slog renders those as
+// "DEBUG+1" / "ERROR+4", so the wire never carries silent garbage.
+func LevelName(l slog.Level) string {
+	switch l {
+	case LevelTrace:
+		return "trace"
+	case slog.LevelDebug:
+		return "debug"
+	case slog.LevelInfo:
+		return "info"
+	case slog.LevelWarn:
+		return "warn"
+	case slog.LevelError:
+		return "error"
+	case LevelFatal:
+		return "fatal"
+	case LevelPanic:
+		return "panic"
+	}
+	return strings.ToLower(l.String())
+}
+
+// ParseLevel converts a canonical level name (case-insensitive) into a
+// slog.Level, returning an error for unrecognized names. Both "warn" and
+// "warning" are accepted.
+func ParseLevel(name string) (slog.Level, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "trace":
+		return LevelTrace, nil
+	case "debug":
+		return slog.LevelDebug, nil
+	case "info":
+		return slog.LevelInfo, nil
+	case "warn", "warning":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	case "fatal":
+		return LevelFatal, nil
+	case "panic":
+		return LevelPanic, nil
+	}
+	return 0, errors.Errorf("invalid log level %q", name)
+}

--- a/logging/levels_test.go
+++ b/logging/levels_test.go
@@ -1,0 +1,80 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLevelNameRoundTrip(t *testing.T) {
+	for _, lvl := range []slog.Level{
+		LevelTrace,
+		slog.LevelDebug,
+		slog.LevelInfo,
+		slog.LevelWarn,
+		slog.LevelError,
+		LevelFatal,
+		LevelPanic,
+	} {
+		name := LevelName(lvl)
+		parsed, err := ParseLevel(name)
+		require.NoError(t, err, "round-trip should succeed for %v", lvl)
+		require.Equal(t, lvl, parsed)
+	}
+}
+
+func TestLevelNameCanonical(t *testing.T) {
+	require.Equal(t, "trace", LevelName(LevelTrace))
+	require.Equal(t, "debug", LevelName(slog.LevelDebug))
+	require.Equal(t, "info", LevelName(slog.LevelInfo))
+	require.Equal(t, "warn", LevelName(slog.LevelWarn))
+	require.Equal(t, "error", LevelName(slog.LevelError))
+	require.Equal(t, "fatal", LevelName(LevelFatal))
+	require.Equal(t, "panic", LevelName(LevelPanic))
+}
+
+// TestLevelNameOffsetFallback proves a non-canonical level value (e.g.
+// slog.LevelDebug+1) emits valid lowercase output via slog.Level.String,
+// rather than collapsing to an empty string or panicking. slog renders
+// offsets relative to the nearest standard level, so the exact string depends
+// on slog's own conventions; we just need it to be non-empty and lowercase.
+func TestLevelNameOffsetFallback(t *testing.T) {
+	require.Equal(t, "debug+1", LevelName(slog.LevelDebug+1))
+	require.Equal(t, "error+1", LevelName(slog.LevelError+1))
+}
+
+func TestParseLevelAcceptsCaseAndWarningAlias(t *testing.T) {
+	lvl, err := ParseLevel("DEBUG")
+	require.NoError(t, err)
+	require.Equal(t, slog.LevelDebug, lvl)
+
+	lvl, err = ParseLevel("warning")
+	require.NoError(t, err)
+	require.Equal(t, slog.LevelWarn, lvl)
+
+	lvl, err = ParseLevel("  Trace  ")
+	require.NoError(t, err)
+	require.Equal(t, LevelTrace, lvl)
+}
+
+func TestParseLevelRejectsUnknown(t *testing.T) {
+	_, err := ParseLevel("bogus")
+	require.Error(t, err)
+}

--- a/logging/options.go
+++ b/logging/options.go
@@ -1,0 +1,72 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// Default AsyncOptions values. See doc/design/logging-refactor.md.
+const (
+	DefaultQueueSize       = 4096
+	DefaultBlockThreshold  = slog.LevelWarn
+	DefaultSummaryInterval = 5 * time.Second
+)
+
+// AsyncOptions configures the AsyncHandler queue, block-threshold, and summary
+// cadence. Zero values are not valid; use DefaultOptions as a starting point.
+type AsyncOptions struct {
+	// QueueSize is the bounded capacity of the records queue between the
+	// handler's caller and the drain goroutine.
+	QueueSize int
+
+	// BlockThreshold is the lowest level at which Handle blocks when the queue
+	// is full. Records strictly below this level are dropped under saturation
+	// and counted toward the next summary line.
+	BlockThreshold slog.Level
+
+	// SummaryInterval is the cadence at which the drain emits a drop-summary
+	// record when any per-level drop counter is non-zero.
+	SummaryInterval time.Duration
+}
+
+// DefaultOptions returns AsyncOptions with the defaults documented in
+// doc/design/logging-refactor.md.
+func DefaultOptions() AsyncOptions {
+	return AsyncOptions{
+		QueueSize:       DefaultQueueSize,
+		BlockThreshold:  DefaultBlockThreshold,
+		SummaryInterval: DefaultSummaryInterval,
+	}
+}
+
+// Validate returns an error if any field is outside its valid range.
+func (o AsyncOptions) Validate() error {
+	if o.QueueSize < 1 {
+		return errors.Errorf("QueueSize must be >= 1, got %d", o.QueueSize)
+	}
+	if o.BlockThreshold < LevelTrace || o.BlockThreshold > LevelPanic {
+		return errors.Errorf("BlockThreshold %v is outside the canonical level range (%v..%v)", o.BlockThreshold, LevelTrace, LevelPanic)
+	}
+	if o.SummaryInterval <= 0 {
+		return errors.Errorf("SummaryInterval must be > 0, got %v", o.SummaryInterval)
+	}
+	return nil
+}

--- a/logging/options_test.go
+++ b/logging/options_test.go
@@ -1,0 +1,52 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultOptionsValid(t *testing.T) {
+	require.NoError(t, DefaultOptions().Validate())
+}
+
+func TestValidateRejectsBadValues(t *testing.T) {
+	tests := map[string]AsyncOptions{
+		"zero queue size":           {QueueSize: 0, BlockThreshold: slog.LevelWarn, SummaryInterval: time.Second},
+		"negative queue size":       {QueueSize: -1, BlockThreshold: slog.LevelWarn, SummaryInterval: time.Second},
+		"threshold below trace":     {QueueSize: 1, BlockThreshold: LevelTrace - 1, SummaryInterval: time.Second},
+		"threshold above panic":     {QueueSize: 1, BlockThreshold: LevelPanic + 1, SummaryInterval: time.Second},
+		"zero summary interval":     {QueueSize: 1, BlockThreshold: slog.LevelWarn, SummaryInterval: 0},
+		"negative summary interval": {QueueSize: 1, BlockThreshold: slog.LevelWarn, SummaryInterval: -time.Second},
+	}
+	for name, opts := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Error(t, opts.Validate())
+		})
+	}
+}
+
+func TestValidateAcceptsBoundaryValues(t *testing.T) {
+	for _, lvl := range []slog.Level{LevelTrace, LevelPanic} {
+		opts := AsyncOptions{QueueSize: 1, BlockThreshold: lvl, SummaryInterval: time.Nanosecond}
+		require.NoError(t, opts.Validate(), "boundary value %v should be accepted", lvl)
+	}
+}

--- a/logging/registry.go
+++ b/logging/registry.go
@@ -1,0 +1,270 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"slices"
+	"sync"
+	"sync/atomic"
+)
+
+// Registry tracks the global log level, per-name level overrides, and the
+// root handler that named loggers attach to. Levels are stored in
+// *slog.LevelVar so any *slog.Logger constructed via For sees subsequent
+// level changes on its next Enabled check, without re-creation.
+//
+// The root handler is held in an atomic.Pointer so SetRoot can swap it
+// without re-creating the Registry: existing Loggers keep pointing at this
+// Registry instance and pick up the new root on their next Handle call.
+// This makes `var log = logging.For(...)` at package-init time safe, since
+// the bootstrap Registry created at init can be re-rooted by Install later
+// without orphaning any loggers.
+//
+// Reads (Enabled checks, For lookups in the cache) take RLock; mutations
+// take the write lock. Level changes are operator actions and not a hot
+// path, so the lock cost on Set/Clear is fine.
+type Registry struct {
+	mu          sync.RWMutex
+	global      *slog.LevelVar
+	overrides   map[string]*slog.LevelVar
+	loggerCache map[string]*slog.Logger
+	root        atomic.Pointer[slog.Handler]
+}
+
+// NewRegistry returns a Registry that sends records to root. Panics if root
+// is nil.
+func NewRegistry(root slog.Handler) *Registry {
+	if root == nil {
+		panic("logging: NewRegistry requires a non-nil root handler")
+	}
+	r := &Registry{
+		global:      new(slog.LevelVar),
+		overrides:   map[string]*slog.LevelVar{},
+		loggerCache: map[string]*slog.Logger{},
+	}
+	r.root.Store(&root)
+	return r
+}
+
+// SetGlobalLevel sets the level used when no per-name override exists.
+// Loggers already constructed via For pick up the new level on their next
+// Enabled check. Pure slog-side; lockstep with logrus happens at the
+// package-level SetGlobalLevel.
+func (r *Registry) SetGlobalLevel(level slog.Level) {
+	r.global.Set(level)
+}
+
+// GlobalLevel returns the current global level.
+func (r *Registry) GlobalLevel() slog.Level {
+	return r.global.Level()
+}
+
+// SetNamedLevel installs or updates a per-name override. The override is
+// held in a *slog.LevelVar created on first use for the name; subsequent
+// SetNamedLevel calls update the same LevelVar, so any Logger view of the
+// name sees the new level live.
+func (r *Registry) SetNamedLevel(name string, level slog.Level) {
+	r.mu.Lock()
+	lv, ok := r.overrides[name]
+	if !ok {
+		lv = new(slog.LevelVar)
+		r.overrides[name] = lv
+	}
+	r.mu.Unlock()
+	lv.Set(level)
+}
+
+// ClearNamedLevel removes the override for name. After clear, the name
+// falls back to the live global level; this is deliberately not "set to
+// the current global" so a later SetGlobalLevel propagates to the
+// previously-overridden name automatically.
+func (r *Registry) ClearNamedLevel(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.overrides, name)
+}
+
+// For returns the *slog.Logger for a named scope, constructed on first use
+// and cached thereafter. Subsequent calls with the same name return the
+// same pointer. The logger's handler chain binds "channel": name as the
+// first attr, so output records always carry the logger name. Panics on
+// empty name (almost always a caller bug).
+func (r *Registry) For(name string) *slog.Logger {
+	if name == "" {
+		panic("logging: For called with empty name")
+	}
+	r.mu.RLock()
+	cached, ok := r.loggerCache[name]
+	r.mu.RUnlock()
+	if ok {
+		return cached
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if cached, ok := r.loggerCache[name]; ok {
+		return cached
+	}
+	nh := &namedHandler{registry: r, name: name}
+	h := nh.WithAttrs([]slog.Attr{slog.String("channel", name)})
+	logger := slog.New(h)
+	r.loggerCache[name] = logger
+	return logger
+}
+
+// HandlerFor returns the bare namedHandler for name, without the
+// channel-attr wrap For provides. Useful for embedding the level-gating
+// handler in a custom chain. Panics on empty name.
+func (r *Registry) HandlerFor(name string) slog.Handler {
+	if name == "" {
+		panic("logging: HandlerFor called with empty name")
+	}
+	return &namedHandler{registry: r, name: name}
+}
+
+// Root returns the registry's current root handler. The package-level
+// RootHandler reads from the default Registry via this method; the logrus
+// bridge uses it to dispatch records, and SyncEmit uses it to find the
+// underlying AsyncHandler when the root is one. Safe under concurrent
+// SetRoot.
+func (r *Registry) Root() slog.Handler {
+	return *r.root.Load()
+}
+
+// SetRoot replaces the registry's root handler atomically. Existing Loggers
+// (constructed by For at any earlier point) pick up the new root on their
+// next Handle call. Configure uses this to install the production handler
+// chain after package init has already handed out loggers via For. Panics
+// if root is nil so the Registry never has a missing destination.
+func (r *Registry) SetRoot(root slog.Handler) {
+	if root == nil {
+		panic("logging: SetRoot requires a non-nil root handler")
+	}
+	r.root.Store(&root)
+}
+
+// resolveLevel returns the effective level for name: the override's level
+// if one is set, otherwise the live global level.
+func (r *Registry) resolveLevel(name string) slog.Level {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if lv, ok := r.overrides[name]; ok {
+		return lv.Level()
+	}
+	return r.global.Level()
+}
+
+// namedHandler is the chain node that does per-name level gating and
+// forwards records to the registry's root handler. Records pass through
+// unchanged; the "channel" attr is added by For's WithAttrs wrap, not here.
+type namedHandler struct {
+	registry *Registry
+	name     string
+}
+
+func (h *namedHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.registry.resolveLevel(h.name)
+}
+
+func (h *namedHandler) Handle(ctx context.Context, r slog.Record) error {
+	return h.registry.Root().Handle(ctx, r)
+}
+
+func (h *namedHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	return &boundHandler{parent: h, attrs: slices.Clone(attrs)}
+}
+
+func (h *namedHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return &groupedHandler{parent: h, name: name}
+}
+
+// defaultRegistry is the process-wide Registry. It is created at package
+// init with a stderr bootstrap root, so For and the other package-level
+// entry points work immediately - including at package-init time, before
+// any process startup code has called Configure. Anything that emits
+// during the bootstrap window (cobra flag parsing, package init) lands on
+// stderr in plain text, so a real startup problem stays visible rather
+// than being silently dropped. Configure later swaps the root handler in
+// place; existing loggers keep working and pick up the new root
+// transparently. The Registry itself is never replaced, so per-name
+// overrides set before Configure persist across it.
+var defaultRegistry = NewRegistry(newBootstrapHandler())
+
+// newBootstrapHandler returns the slog.Handler used as the default
+// Registry's root before Configure runs. Plain text to stderr at the
+// lowest level: gating still happens upstream in namedHandler against
+// the Registry's global level, so this handler accepts whatever passes
+// that gate. Once Install calls Configure, this handler is replaced.
+func newBootstrapHandler() slog.Handler {
+	return slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: LevelTrace})
+}
+
+// DefaultRegistry returns the package-level default Registry. Useful for
+// tests that need a stable handle to reset state, and for code that wants
+// to bypass the package-level conveniences entirely.
+func DefaultRegistry() *Registry {
+	return defaultRegistry
+}
+
+// Configure installs root as the default Registry's root handler. It
+// replaces the bootstrap stderr root from init time (or whatever a prior
+// Configure call set) without re-creating the Registry, so existing
+// loggers and per-name overrides survive. Install calls this from PreRun.
+func Configure(root slog.Handler) {
+	defaultRegistry.SetRoot(root)
+}
+
+// For returns the named logger from the default Registry.
+func For(name string) *slog.Logger {
+	return defaultRegistry.For(name)
+}
+
+// HandlerFor returns the bare named handler from the default Registry.
+func HandlerFor(name string) slog.Handler {
+	return defaultRegistry.HandlerFor(name)
+}
+
+// SetGlobalLevel sets the global level on the default Registry. Named loggers
+// see the new threshold on their next Enabled check. This is the pure slog
+// view; callers that also bridge logrus (see the ziti logsetup package) wrap
+// this to drive logrus's level in lockstep.
+func SetGlobalLevel(level slog.Level) {
+	defaultRegistry.SetGlobalLevel(level)
+}
+
+// GlobalLevel returns the global level on the default Registry.
+func GlobalLevel() slog.Level {
+	return defaultRegistry.GlobalLevel()
+}
+
+// SetNamedLevel sets a per-name override on the default Registry.
+func SetNamedLevel(name string, level slog.Level) {
+	defaultRegistry.SetNamedLevel(name, level)
+}
+
+// ClearNamedLevel removes a per-name override on the default Registry.
+func ClearNamedLevel(name string) {
+	defaultRegistry.ClearNamedLevel(name)
+}

--- a/logging/registry_test.go
+++ b/logging/registry_test.go
@@ -1,0 +1,285 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newTestRegistry returns a Registry whose root is an AsyncHandler over the
+// given downstream, along with the AsyncHandler so the caller can Close it
+// and wait for drain.
+func newTestRegistry(t *testing.T, downstream slog.Handler) (*Registry, *AsyncHandler) {
+	t.Helper()
+	h, err := NewAsyncHandler(downstream, DefaultOptions())
+	require.NoError(t, err)
+	return NewRegistry(h), h
+}
+
+func TestRegistryNewRejectsNilRoot(t *testing.T) {
+	require.Panics(t, func() { NewRegistry(nil) })
+}
+
+func TestRegistryForPanicsOnEmpty(t *testing.T) {
+	rec := &recordingHandler{}
+	r, async := newTestRegistry(t, rec)
+	defer func() { _ = async.Close(); <-async.drainDone }()
+	require.Panics(t, func() { r.For("") })
+	require.Panics(t, func() { r.HandlerFor("") })
+}
+
+func TestRegistryForCachesLoggers(t *testing.T) {
+	rec := &recordingHandler{}
+	r, async := newTestRegistry(t, rec)
+	defer func() { _ = async.Close(); <-async.drainDone }()
+	require.Same(t, r.For("x"), r.For("x"))
+}
+
+func TestRegistryGlobalLevelGates(t *testing.T) {
+	rec := &recordingHandler{}
+	r, async := newTestRegistry(t, rec)
+	r.SetGlobalLevel(slog.LevelInfo)
+
+	logger := r.For("x")
+	logger.Debug("dropped-debug")
+	logger.Info("kept-info")
+
+	require.NoError(t, async.Close())
+	<-async.drainDone
+
+	var msgs []string
+	for _, r := range rec.snapshot() {
+		msgs = append(msgs, r.Message)
+	}
+	require.Equal(t, []string{"kept-info"}, msgs)
+}
+
+func TestRegistryNamedLevelOverridesGlobal(t *testing.T) {
+	rec := &recordingHandler{}
+	r, async := newTestRegistry(t, rec)
+	r.SetGlobalLevel(slog.LevelInfo)
+	r.SetNamedLevel("x", slog.LevelDebug)
+
+	r.For("x").Debug("x-debug")
+	r.For("y").Debug("y-debug-dropped")
+	r.For("y").Info("y-info")
+
+	require.NoError(t, async.Close())
+	<-async.drainDone
+
+	var msgs []string
+	for _, r := range rec.snapshot() {
+		msgs = append(msgs, r.Message)
+	}
+	require.ElementsMatch(t, []string{"x-debug", "y-info"}, msgs)
+}
+
+// TestRegistryClearNamedLevelRevertsToGlobal confirms ClearNamedLevel falls
+// back to the live global, not a snapshot of it.
+func TestRegistryClearNamedLevelRevertsToGlobal(t *testing.T) {
+	rec := &recordingHandler{}
+	r, async := newTestRegistry(t, rec)
+	defer func() { _ = async.Close(); <-async.drainDone }()
+
+	r.SetGlobalLevel(slog.LevelInfo)
+	r.SetNamedLevel("x", slog.LevelDebug)
+	require.True(t, r.For("x").Enabled(context.Background(), slog.LevelDebug))
+
+	r.ClearNamedLevel("x")
+	require.False(t, r.For("x").Enabled(context.Background(), slog.LevelDebug), "after clear, x should track the global")
+
+	r.SetGlobalLevel(slog.LevelDebug)
+	require.True(t, r.For("x").Enabled(context.Background(), slog.LevelDebug), "global change should reach the previously-overridden name")
+}
+
+// TestRegistryLevelChangesAffectExistingLoggers proves a Logger created
+// before a level change reflects the new level on its next Enabled check.
+func TestRegistryLevelChangesAffectExistingLoggers(t *testing.T) {
+	rec := &recordingHandler{}
+	r, async := newTestRegistry(t, rec)
+	defer func() { _ = async.Close(); <-async.drainDone }()
+
+	r.SetGlobalLevel(slog.LevelInfo)
+	logger := r.For("x")
+	require.False(t, logger.Enabled(context.Background(), slog.LevelDebug))
+
+	r.SetGlobalLevel(slog.LevelDebug)
+	require.True(t, logger.Enabled(context.Background(), slog.LevelDebug))
+}
+
+// TestRegistryComposedNamedLogger covers the design's acceptance gate:
+//
+//	For("router.link").WithGroup("g").With("k","v").Info("msg","x",1)
+//	  -> {msg, channel:"router.link", g:{k:"v", x:1}}
+func TestRegistryComposedNamedLogger(t *testing.T) {
+	buf := &bytes.Buffer{}
+	downstream := slog.NewJSONHandler(buf, &slog.HandlerOptions{
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey || a.Key == slog.LevelKey {
+				return slog.Attr{}
+			}
+			return a
+		},
+	})
+	r, async := newTestRegistry(t, downstream)
+	r.For("router.link").WithGroup("g").With("k", "v").Info("msg", "x", 1)
+
+	require.NoError(t, async.Close())
+	<-async.drainDone
+
+	line := strings.TrimSpace(buf.String())
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &got), "raw=%q", line)
+	require.Equal(t, "msg", got["msg"])
+	require.Equal(t, "router.link", got["channel"])
+	g, ok := got["g"].(map[string]any)
+	require.True(t, ok, "g should be a nested object, got %T", got["g"])
+	require.Equal(t, "v", g["k"])
+	require.Equal(t, float64(1), g["x"])
+}
+
+// TestPackageDefaultWorksBeforeConfigure proves every package-level entry
+// point is callable on the bootstrap Registry that init creates. Records
+// emitted in the pre-Configure window are dropped silently by the discard
+// root. This is the property that makes `var log = logging.For(...)` at
+// package-init time safe.
+func TestPackageDefaultWorksBeforeConfigure(t *testing.T) {
+	resetDefaultForTest()
+	require.NotPanics(t, func() { _ = For("x") })
+	require.NotPanics(t, func() { SetGlobalLevel(slog.LevelInfo) })
+	require.NotPanics(t, func() { SetNamedLevel("x", slog.LevelDebug) })
+	require.NotPanics(t, func() { ClearNamedLevel("x") })
+	require.NotPanics(t, func() { _ = GlobalLevel() })
+	require.NotPanics(t, func() { _ = HandlerFor("x") })
+
+	// A log call against For-logger goes through the bootstrap discard root
+	// without error; the discard's Enabled returns false but namedHandler's
+	// own gate is independent, so Handle is reached and silently drops the
+	// record.
+	require.NotPanics(t, func() { For("x").Info("dropped-silently") })
+}
+
+func TestPackageDefaultThroughConfigure(t *testing.T) {
+	resetDefaultForTest()
+	rec := &recordingHandler{}
+	async, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	defer func() { _ = async.Close(); <-async.drainDone }()
+
+	Configure(async)
+	SetGlobalLevel(slog.LevelInfo)
+	require.Equal(t, slog.LevelInfo, GlobalLevel())
+
+	SetNamedLevel("x", slog.LevelDebug)
+	require.True(t, For("x").Enabled(context.Background(), slog.LevelDebug))
+
+	ClearNamedLevel("x")
+	require.False(t, For("x").Enabled(context.Background(), slog.LevelDebug))
+}
+
+// TestConfigureSwapsRootInPlace proves a second Configure call replaces the
+// default Registry's root handler without re-creating the Registry. Loggers
+// captured before the swap stay valid: their next log call goes to the new
+// root. This is the property that lets `var log = logging.For(...)`
+// declarations land at package-init time and still work after Install
+// runs from PreRun.
+func TestConfigureSwapsRootInPlace(t *testing.T) {
+	resetDefaultForTest()
+
+	rec1 := &recordingHandler{}
+	Configure(rec1)
+	SetGlobalLevel(slog.LevelInfo)
+	log := For("x")
+
+	log.Info("first")
+	require.Equal(t, 1, rec1.count(), "first record reaches the initial root")
+
+	rec2 := &recordingHandler{}
+	Configure(rec2)
+
+	log.Info("second")
+	require.Equal(t, 1, rec1.count(), "post-swap records must not reach the previous root")
+	require.Equal(t, 1, rec2.count(), "post-swap records reach the new root via the same logger")
+
+	require.Same(t, log, For("x"), "Configure swap must preserve the logger cache")
+}
+
+// TestRegistryConcurrentSetAndFor stress-tests concurrent For lookups and
+// SetNamedLevel calls. Run under -race; the test passes if nothing panics
+// and the race detector finds no data races.
+func TestRegistryConcurrentSetAndFor(t *testing.T) {
+	rec := &recordingHandler{}
+	r, async := newTestRegistry(t, rec)
+	defer func() { _ = async.Close(); <-async.drainDone }()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(3)
+		go func(i int) {
+			defer wg.Done()
+			r.For(fmt.Sprintf("logger-%d", i%4)).Info("x")
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			r.SetNamedLevel(fmt.Sprintf("logger-%d", i%4), slog.LevelDebug)
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				r.ClearNamedLevel(fmt.Sprintf("logger-%d", i%4))
+			} else {
+				r.SetGlobalLevel(slog.LevelInfo)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// discardHandler is used as the test-reset root: tests don't want the
+// bootstrap stderr handler's output in their captured streams, and the
+// rooted recording handlers tests typically install replace it anyway.
+type discardHandler struct{}
+
+func (discardHandler) Enabled(context.Context, slog.Level) bool  { return false }
+func (discardHandler) Handle(context.Context, slog.Record) error { return nil }
+func (h discardHandler) WithAttrs([]slog.Attr) slog.Handler      { return h }
+func (h discardHandler) WithGroup(string) slog.Handler           { return h }
+
+// resetDefaultForTest restores the package default Registry to a clean
+// baseline: root reset to a silent discard (so test reset itself doesn't
+// emit on stderr), overrides and logger cache cleared, global level
+// reset to Info. Tests call this at start so they don't inherit state
+// from earlier tests in the same binary. The Registry itself is the
+// same instance throughout the test binary; only its internals are
+// reset.
+func resetDefaultForTest() {
+	defaultRegistry.mu.Lock()
+	defaultRegistry.overrides = map[string]*slog.LevelVar{}
+	defaultRegistry.loggerCache = map[string]*slog.Logger{}
+	defaultRegistry.mu.Unlock()
+	defaultRegistry.SetRoot(discardHandler{})
+	defaultRegistry.global.Set(slog.LevelInfo)
+}


### PR DESCRIPTION
## Summary

Extracts the minimal slog logging core from ziti's `common/logging` into `foundation/v2/logging` so upstream libraries (channel, sdk-golang, transport, ...) can use named slog loggers from the same registry. Part of the logging refactor in openziti/ziti#3910.

Fixes #484.

## What's here (moved unchanged from ziti)

- custom levels (trace/fatal/panic) plus `LevelName`/`ParseLevel`
- the bound/grouped/named slog handler chain
- the named-logger `Registry` (`For` / `Configure` / `SetGlobalLevel` / `SetNamedLevel` / `ClearNamedLevel`)
- the bounded `AsyncHandler` and `AsyncOptions`
- the package's tests (45 tests, race-clean)

Depends only on the stdlib and `pkg/errors` — no logrus, no pflag.

## Not here (stays in ziti)

The logrus bridge (`Install`/`InstallTo`/`SyncEmit`/`Fatal`), the formatters (pretty/JSON), and the pflag flag binding remain in ziti's logging/setup package. The package-level `SetGlobalLevel` is pure slog here; ziti keeps the logrus-lockstep wrapper.
