### PR TITLE
Add slog.Handler interface gates and Fatal/SyncEmit logging helpers

### DIFF
--- a/logging/chain.go
+++ b/logging/chain.go
@@ -34,6 +34,8 @@ type boundHandler struct {
 	attrs  []slog.Attr
 }
 
+var _ slog.Handler = (*boundHandler)(nil)
+
 func (h *boundHandler) Enabled(ctx context.Context, level slog.Level) bool {
 	return h.parent.Enabled(ctx, level)
 }
@@ -72,6 +74,8 @@ type groupedHandler struct {
 	parent slog.Handler
 	name   string
 }
+
+var _ slog.Handler = (*groupedHandler)(nil)
 
 func (h *groupedHandler) Enabled(ctx context.Context, level slog.Level) bool {
 	return h.parent.Enabled(ctx, level)

--- a/logging/fatal.go
+++ b/logging/fatal.go
@@ -1,0 +1,64 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"runtime"
+	"time"
+)
+
+// SyncEmit writes r through the default Registry's root handler synchronously
+// on the caller's goroutine. If the root is an *AsyncHandler, the call routes
+// through its SyncEmit, which flushes the queued records and then writes r
+// under the same mutex the drain uses, so the buffered context leading up to
+// the call survives a process exit right after. Otherwise it falls back to
+// Handle, which is already synchronous for any non-async handler.
+//
+// It is the durability primitive behind Fatal, and is available to callers that
+// need the same guarantee for a record they build themselves.
+func SyncEmit(ctx context.Context, r slog.Record) error {
+	root := DefaultRegistry().Root()
+	if ah, ok := root.(*AsyncHandler); ok {
+		return ah.SyncEmit(ctx, r)
+	}
+	return root.Handle(ctx, r)
+}
+
+// osExit is os.Exit, indirected so tests can exercise Fatal without
+// terminating the test process.
+var osExit = os.Exit
+
+// Fatal writes msg at LevelFatal and then exits the process with status 1. It
+// is the slog-world equivalent of logrus.Fatal, which slog does not provide
+// (slog has only Debug/Info/Warn/Error and never exits the process itself).
+//
+// The record is emitted durably through SyncEmit, so it flushes any queued
+// records and writes synchronously before the exit, and it bypasses level
+// gating so a fatal is never filtered out. Hard-exit paths call this instead
+// of logging an Error and then calling os.Exit or panic: those drop the record
+// because the async queue never drains before the process is gone.
+func Fatal(ctx context.Context, msg string, attrs ...slog.Attr) {
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip runtime.Callers + this frame
+	r := slog.NewRecord(time.Now(), LevelFatal, msg, pcs[0])
+	r.AddAttrs(attrs...)
+	_ = SyncEmit(ctx, r)
+	osExit(1)
+}

--- a/logging/fatal_test.go
+++ b/logging/fatal_test.go
@@ -1,0 +1,95 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSyncEmitDeliversThroughAsyncRoot proves the package-level SyncEmit routes
+// through the *AsyncHandler root synchronously: the record reaches the
+// downstream before SyncEmit returns, without waiting for the async drain.
+func TestSyncEmitDeliversThroughAsyncRoot(t *testing.T) {
+	resetDefaultForTest()
+	rec := &recordingHandler{}
+	async, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	defer func() { _ = async.Close() }()
+	Configure(async)
+
+	r := slog.NewRecord(time.Now(), slog.LevelInfo, "sync-msg", 0)
+	require.NoError(t, SyncEmit(context.Background(), r))
+
+	require.Equal(t, 1, rec.count(), "SyncEmit must write before returning, not leave the record queued")
+	require.Equal(t, "sync-msg", rec.snapshot()[0].Message)
+}
+
+// TestSyncEmitFallsBackForNonAsyncRoot proves SyncEmit handles a Registry whose
+// root is not an *AsyncHandler by falling back to Handle. Handle on a non-async
+// handler is already synchronous, so durability is preserved.
+func TestSyncEmitFallsBackForNonAsyncRoot(t *testing.T) {
+	resetDefaultForTest()
+	rec := &recordingHandler{}
+	Configure(rec) // root is the plain recording handler, not an AsyncHandler
+
+	r := slog.NewRecord(time.Now(), LevelFatal, "fatal-fallback", 0)
+	require.NoError(t, SyncEmit(context.Background(), r))
+	require.Equal(t, 1, rec.count())
+}
+
+// TestFatalEmitsDurablyAndExits proves Fatal writes its record synchronously
+// (present before any Close, so it survives a process exit), carries the attrs
+// and caller PC, and calls osExit(1). The global level is set above Fatal to
+// also prove Fatal bypasses level gating, matching logrus.Fatal.
+func TestFatalEmitsDurablyAndExits(t *testing.T) {
+	resetDefaultForTest()
+	rec := &recordingHandler{}
+	async, err := NewAsyncHandler(rec, DefaultOptions())
+	require.NoError(t, err)
+	defer func() { _ = async.Close() }()
+	Configure(async)
+	SetGlobalLevel(LevelPanic) // above Fatal: a gated path would drop it
+
+	var gotCode int
+	var exited bool
+	prev := osExit
+	osExit = func(code int) { gotCode = code; exited = true }
+	defer func() { osExit = prev }()
+
+	Fatal(context.Background(), "boom", slog.String("k", "v"))
+
+	require.True(t, exited, "Fatal must call osExit")
+	require.Equal(t, 1, gotCode)
+	require.Equal(t, 1, rec.count(), "record must be written synchronously, not left in the queue")
+
+	got := rec.snapshot()[0]
+	require.Equal(t, LevelFatal, got.Level)
+	require.Equal(t, "boom", got.Message)
+	require.NotZero(t, got.PC, "Fatal should capture the caller PC")
+
+	attrs := map[string]string{}
+	got.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.String()
+		return true
+	})
+	require.Equal(t, "v", attrs["k"])
+}

--- a/logging/handler.go
+++ b/logging/handler.go
@@ -54,6 +54,8 @@ type AsyncHandler struct {
 	windowStart time.Time
 }
 
+var _ slog.Handler = (*AsyncHandler)(nil)
+
 // queuedRecord carries the originating call's context alongside the record so
 // downstream handlers that consult ctx values (tracing, OTel) see them across
 // the async hop.

--- a/logging/registry.go
+++ b/logging/registry.go
@@ -178,6 +178,8 @@ type namedHandler struct {
 	name     string
 }
 
+var _ slog.Handler = (*namedHandler)(nil)
+
 func (h *namedHandler) Enabled(_ context.Context, level slog.Level) bool {
 	return level >= h.registry.resolveLevel(h.name)
 }


### PR DESCRIPTION
Two follow-ups to the slog logging core (#485), bundled together.

**Interface gates.** Addresses a review comment missed before #485 merged: adds `var _ slog.Handler = (*T)(nil)` compile-time assertions for the four slog.Handler implementations in `logging` (`boundHandler`, `groupedHandler`, `namedHandler`, `AsyncHandler`), so interface conformance is enforced at compile time.

**Fatal/SyncEmit helpers (#488).** Promotes two package-level helpers into `logging`: `SyncEmit`, which writes a record synchronously through the default registry root (routing through the async handler when one is configured), and `Fatal`, the slog equivalent of `logrus.Fatal` that emits durably and then exits. These are logrus-free and currently live only in ziti's logsetup; moving them here lets upstream libraries converting off pfxlog share one durable-exit helper instead of hand-rolling an error log plus os.Exit.